### PR TITLE
Chainable varargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Montrose::Recurrence.new(every: :minute, until: "9:00 PM")
 
 # Daily
 Montrose.daily
+Montrose.every(:day)
 Montrose::Recurrence.new(every: :day)
 
 Montrose.every(9.days)
@@ -218,18 +219,15 @@ Montrose.daily(except: [Date.today, "2017-01-31"])
 # Chaining
 Montrose.weekly.starting(3.weeks.from_now).on(:friday)
 Montrose.every(:day).at("4:05pm")
+Montrose.yearly.between(Time.now..10.years.from_now)
 
 # Enumerating events
 r = Montrose.every(:month, mday: 31, until: "January 1, 2017")
 r.each { |time| puts time.to_s }
 r.take(10).to_a
 
-# Merging rules and enumerating
+# Merging rules
 r.merge(starts: "2017-01-01").each { |time| puts time.to_s }
-r.merge(starts: "2017-01-01").each { |date| puts date.to_s }
-r.merge(until: "2017-01-10").each { |date| puts date.to_s }
-r.merge(through: "2017-01-10").each { |date| puts date.to_s }
-r.merge(starts: "2017-01-05", until: "2017-01-10").each {|date| puts date.to_s }
 
 # Using #events Enumerator
 r.events # => #<Enumerator: ...>

--- a/lib/montrose/chainable.rb
+++ b/lib/montrose/chainable.rb
@@ -1,7 +1,10 @@
 require "montrose/options"
+require "montrose/refinements/array_concat"
 
 module Montrose
   module Chainable
+    using Montrose::Refinements::ArrayConcat
+
     # Create a recurrence from the given frequency
     # @example
     #
@@ -146,7 +149,7 @@ module Montrose
     # @param [Fixnum] days (1, 2, -1, ...)
     #
     def day_of_month(days, *extras)
-      merge(mday: Array(days) + extras)
+      merge(mday: days.array_concat(extras))
     end
     alias mday day_of_month
 
@@ -155,7 +158,7 @@ module Montrose
     # @param [Symbol] weekdays (:sunday, :monday, ...)
     #
     def day_of_week(weekdays, *extras)
-      merge(day: Array(weekdays) + extras)
+      merge(day: weekdays.array_concat(extras))
     end
     alias day day_of_week
 
@@ -164,7 +167,7 @@ module Montrose
     # @param [Fixnum] days (1, 10, 100, ...)
     #
     def day_of_year(days, *extras)
-      merge(yday: Array(days) + extras)
+      merge(yday: days.array_concat(extras))
     end
     alias yday day_of_year
 
@@ -173,7 +176,7 @@ module Montrose
     # @param [Fixnum, Range] days (1, 10, 100, ...)
     #
     def hour_of_day(hours, *extras)
-      merge(hour: Array(hours) + extras)
+      merge(hour: hours.array_concat(extras))
     end
     alias hour hour_of_day
 
@@ -182,7 +185,7 @@ module Montrose
     # @param [Fixnum, Symbol] months (:january, :april, ...)
     #
     def month_of_year(months, *extras)
-      merge(month: Array(months) + extras)
+      merge(month: months.array_concat(extras))
     end
     alias month month_of_year
 
@@ -200,7 +203,7 @@ module Montrose
     # @param [Fixnum] weeks (1, 20, 50)
     #
     def week_of_year(weeks, *extras)
-      merge(week: Array(weeks) + extras)
+      merge(week: weeks.array_concat(extras))
     end
 
     # @private

--- a/lib/montrose/chainable.rb
+++ b/lib/montrose/chainable.rb
@@ -145,8 +145,8 @@ module Montrose
     #
     # @param [Fixnum] days (1, 2, -1, ...)
     #
-    def day_of_month(*days)
-      merge(mday: days)
+    def day_of_month(days, *extras)
+      merge(mday: Array(days) + extras)
     end
     alias mday day_of_month
 
@@ -154,8 +154,8 @@ module Montrose
     #
     # @param [Symbol] weekdays (:sunday, :monday, ...)
     #
-    def day_of_week(*weekdays)
-      merge(day: weekdays)
+    def day_of_week(weekdays, *extras)
+      merge(day: Array(weekdays) + extras)
     end
     alias day day_of_week
 
@@ -163,8 +163,8 @@ module Montrose
     #
     # @param [Fixnum] days (1, 10, 100, ...)
     #
-    def day_of_year(*days)
-      merge(yday: days)
+    def day_of_year(days, *extras)
+      merge(yday: Array(days) + extras)
     end
     alias yday day_of_year
 
@@ -172,8 +172,8 @@ module Montrose
     #
     # @param [Fixnum, Range] days (1, 10, 100, ...)
     #
-    def hour_of_day(*hours)
-      merge(hour: hours)
+    def hour_of_day(hours, *extras)
+      merge(hour: Array(hours) + extras)
     end
     alias hour hour_of_day
 
@@ -181,8 +181,8 @@ module Montrose
     #
     # @param [Fixnum, Symbol] months (:january, :april, ...)
     #
-    def month_of_year(*months)
-      merge(month: months)
+    def month_of_year(months, *extras)
+      merge(month: Array(months) + extras)
     end
     alias month month_of_year
 
@@ -199,8 +199,8 @@ module Montrose
     #
     # @param [Fixnum] weeks (1, 20, 50)
     #
-    def week_of_year(*weeks)
-      merge(week: weeks)
+    def week_of_year(weeks, *extras)
+      merge(week: Array(weeks) + extras)
     end
 
     # @private

--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -272,7 +272,7 @@ module Montrose
 
     def assert_range_includes(range, item, absolute = false)
       test = absolute ? item.abs : item
-      fail ConfigurationError, "Out of range" unless range.include?(test)
+      fail ConfigurationError, "Out of range: #{range.inspect} does not include #{test}" unless range.include?(test)
 
       item
     end

--- a/lib/montrose/refinements/array_concat.rb
+++ b/lib/montrose/refinements/array_concat.rb
@@ -1,0 +1,11 @@
+module Montrose
+  module Refinements
+    module ArrayConcat
+      refine Object do
+        def array_concat(other)
+          Array(self) + other
+        end
+      end
+    end
+  end
+end

--- a/spec/montrose/chainable_spec.rb
+++ b/spec/montrose/chainable_spec.rb
@@ -142,17 +142,53 @@ describe Montrose::Chainable do
       Time.local(2015, 9, 5, 12).wday.must_equal 6
       Time.local(2015, 9, 6, 12).wday.must_equal 0
     end
+
+    it "returns new recurrence by given range of days" do
+      recurrence = Montrose.weekly
+      recurrence = recurrence.day_of_week(1..3)
+
+      recurrence.events.must_pair_with [
+        Time.local(2015, 9, 1, 12), # Tuesday
+        Time.local(2015, 9, 2, 12),
+        Time.local(2015, 9, 7, 12)
+      ]
+    end
   end
 
   describe "#day_of_year" do
-    it "returns new recurrence by given days of month" do
+    it "returns new recurrence by given days of year" do
       recurrence = Montrose.yearly
       recurrence = recurrence.day_of_year(1, 10, 100)
 
       recurrence.events.must_pair_with [
         Time.local(2016, 1, 1, 12),
         Time.local(2016, 1, 10, 12),
-        Time.local(2016, 4, 9, 12) # 100th day
+        Time.local(2016, 4, 9, 12), # 100th day
+        Time.local(2017, 1, 1, 12)
+      ]
+    end
+
+    it "returns new recurrence by given array of days" do
+      recurrence = Montrose.yearly
+      recurrence = recurrence.day_of_year([1, 10, 100])
+
+      recurrence.events.must_pair_with [
+        Time.local(2016, 1, 1, 12),
+        Time.local(2016, 1, 10, 12),
+        Time.local(2016, 4, 9, 12), # 100th day
+        Time.local(2017, 1, 1, 12)
+      ]
+    end
+
+    it "returns new recurrence by given range of days" do
+      recurrence = Montrose.yearly
+      recurrence = recurrence.day_of_year(98..100)
+
+      recurrence.events.must_pair_with [
+        Time.local(2016, 4, 7, 12),
+        Time.local(2016, 4, 8, 12),
+        Time.local(2016, 4, 9, 12), # 100th day
+        Time.local(2017, 4, 8, 12)
       ]
     end
   end
@@ -161,6 +197,30 @@ describe Montrose::Chainable do
     it "returns new recurrence by given hours of day" do
       recurrence = Montrose.daily
       recurrence = recurrence.hour_of_day(6, 7, 8)
+
+      recurrence.events.must_pair_with [
+        Time.local(2015, 9, 2, 6),
+        Time.local(2015, 9, 2, 7),
+        Time.local(2015, 9, 2, 8),
+        Time.local(2015, 9, 3, 6)
+      ]
+    end
+
+    it "returns new recurrence by given array of hours" do
+      recurrence = Montrose.daily
+      recurrence = recurrence.hour_of_day([6, 7, 8])
+
+      recurrence.events.must_pair_with [
+        Time.local(2015, 9, 2, 6),
+        Time.local(2015, 9, 2, 7),
+        Time.local(2015, 9, 2, 8),
+        Time.local(2015, 9, 3, 6)
+      ]
+    end
+
+    it "returns new recurrence by given range of hours" do
+      recurrence = Montrose.daily
+      recurrence = recurrence.hour_of_day(6..8)
 
       recurrence.events.must_pair_with [
         Time.local(2015, 9, 2, 6),
@@ -179,6 +239,29 @@ describe Montrose::Chainable do
       recurrence.events.must_pair_with [
         Time.local(2016, 1, 1, 12),
         Time.local(2016, 4, 1, 12),
+        Time.local(2017, 1, 1, 12)
+      ]
+    end
+
+    it "returns new recurrence by given array of months" do
+      recurrence = Montrose.yearly
+      recurrence = recurrence.month_of_year([:january, :april])
+
+      recurrence.events.must_pair_with [
+        Time.local(2016, 1, 1, 12),
+        Time.local(2016, 4, 1, 12),
+        Time.local(2017, 1, 1, 12)
+      ]
+    end
+
+    it "returns new recurrence by given range of months" do
+      recurrence = Montrose.yearly
+      recurrence = recurrence.month_of_year(1..3)
+
+      recurrence.events.must_pair_with [
+        Time.local(2016, 1, 1, 12),
+        Time.local(2016, 2, 1, 12),
+        Time.local(2016, 3, 1, 12),
         Time.local(2017, 1, 1, 12)
       ]
     end
@@ -208,6 +291,17 @@ describe Montrose::Chainable do
       recurrence.events.must_pair_with [
         Time.local(2015, 12, 21, 12), # Monday, 52nd week
         Time.local(2016, 1, 4, 12) # Monday, 1st week
+      ]
+    end
+
+    it "returns new recurrence by given range of weeks" do
+      recurrence = Montrose.yearly
+      recurrence = recurrence.day_of_week(:monday).week_of_year(50..52)
+
+      recurrence.events.must_pair_with [
+        Time.local(2015, 12, 7, 12),
+        Time.local(2015, 12, 14, 12),
+        Time.local(2015, 12, 21, 12) # Monday, 52nd week
       ]
     end
   end


### PR DESCRIPTION
Selected `Chainable` methods should accept both varargs and array-like objects:

The following would be equivalent:
```ruby
Montrose.monthly.day_of_month(6, 7, 8)
Montrose.monthly.day_of_month([6, 7, 8])
Montrose.monthly.day_of_month(6..8)
```