### PR TITLE
Fewer instance default options

### DIFF
--- a/lib/montrose/clock.rb
+++ b/lib/montrose/clock.rb
@@ -3,7 +3,7 @@ require "montrose/errors"
 module Montrose
   class Clock
     def initialize(opts = {})
-      @options = Montrose::Options.new(opts)
+      @options = Montrose::Options.merge(opts)
       @time = nil
       @every = @options.fetch(:every) { fail ConfigurationError, "Required option :every not provided" }
       @starts = @options.fetch(:starts)

--- a/lib/montrose/frequency.rb
+++ b/lib/montrose/frequency.rb
@@ -43,7 +43,7 @@ module Montrose
     end
 
     def initialize(opts = {})
-      opts = Montrose::Options.new(opts)
+      opts = Montrose::Options.merge(opts)
       @time = nil
       @starts = opts.fetch(:starts)
       @interval = opts.fetch(:interval)

--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -66,7 +66,8 @@ module Montrose
       def default_options
         {
           starts: default_starts,
-          until: default_until
+          until: default_until,
+          interval: 1
         }
       end
     end
@@ -89,7 +90,7 @@ module Montrose
     def initialize(opts = {})
       defaults = {
         every: self.class.default_every,
-        interval: 1,
+        interval: nil,
         starts: nil,
         until: nil,
         day: nil,

--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -58,6 +58,17 @@ module Montrose
           @default_starts
         end
       end
+
+      def merge(opts = {})
+        new(default_options).merge(opts)
+      end
+
+      def default_options
+        {
+          starts: default_starts,
+          until: default_until
+        }
+      end
     end
 
     def_option :every
@@ -78,9 +89,9 @@ module Montrose
     def initialize(opts = {})
       defaults = {
         every: self.class.default_every,
-        starts: self.class.default_starts,
-        until: self.class.default_until,
         interval: 1,
+        starts: nil,
+        until: nil,
         day: nil,
         mday: nil,
         yday: nil,

--- a/lib/montrose/recurrence.rb
+++ b/lib/montrose/recurrence.rb
@@ -56,7 +56,7 @@ module Montrose
     private
 
     def event_enum
-      opts = @default_options
+      opts = Options.merge(@default_options)
       stack = Stack.new(opts)
       clock = Clock.new(opts)
 

--- a/spec/montrose/options_spec.rb
+++ b/spec/montrose/options_spec.rb
@@ -166,15 +166,18 @@ describe Montrose::Options do
     end
 
     it "defaults to current time" do
-      options.starts.must_equal time_now
-      options[:starts].must_equal time_now
+      default = Montrose::Options.merge(options)
+
+      default.starts.must_equal time_now
+      default[:starts].must_equal time_now
     end
 
     it "defaults to default_until time" do
       Montrose::Options.default_starts = 3.days.from_now
+      default = Montrose::Options.merge(options)
 
-      options.starts.must_equal 3.days.from_now
-      options[:starts].must_equal 3.days.from_now
+      default.starts.must_equal 3.days.from_now
+      default[:starts].must_equal 3.days.from_now
     end
 
     it "can be set" do
@@ -223,9 +226,10 @@ describe Montrose::Options do
 
     it "defaults to default_until time" do
       Montrose::Options.default_until = 3.days.from_now
+      default = Montrose::Options.merge(options)
 
-      options.until.must_equal 3.days.from_now
-      options[:until].must_equal 3.days.from_now
+      default.until.must_equal 3.days.from_now
+      default[:until].must_equal 3.days.from_now
     end
 
     it "can be set" do
@@ -673,10 +677,7 @@ describe Montrose::Options do
     end
 
     it "returns Hash with non-nil key-value pairs" do
-      options.to_hash.must_equal(
-        every: :day,
-        starts: time_now,
-        interval: 1)
+      options.to_hash.must_equal(every: :day, interval: 1)
     end
   end
 

--- a/spec/montrose/options_spec.rb
+++ b/spec/montrose/options_spec.rb
@@ -280,8 +280,10 @@ describe Montrose::Options do
 
   describe "#interval" do
     it "defaults to 1" do
-      options.interval.must_equal 1
-      options[:interval].must_equal 1
+      default = Montrose::Options.merge(options)
+
+      default.interval.must_equal 1
+      default[:interval].must_equal 1
     end
 
     it "can be set" do
@@ -677,7 +679,7 @@ describe Montrose::Options do
     end
 
     it "returns Hash with non-nil key-value pairs" do
-      options.to_hash.must_equal(every: :day, interval: 1)
+      options.to_hash.must_equal(every: :day)
     end
   end
 
@@ -715,6 +717,7 @@ describe Montrose::Options do
     before do
       options[:every] = :month
       options[:starts] = now
+      options[:interval] = 1
     end
 
     it { options.inspect.must_equal "#<Montrose::Options {:every=>:month, :starts=>#{now.inspect}, :interval=>1}>" }

--- a/spec/montrose/recurrence_spec.rb
+++ b/spec/montrose/recurrence_spec.rb
@@ -120,7 +120,7 @@ describe Montrose::Recurrence do
 
   describe "#inspect" do
     let(:now) { time_now }
-    let(:recurrence) { new_recurrence(every: :month, starts: now) }
+    let(:recurrence) { new_recurrence(every: :month, starts: now, interval: 1) }
 
     it do
       inspected = "#<Montrose::Recurrence:#{recurrence.object_id.to_s(16)} "


### PR DESCRIPTION
We want to avoid mixing default options with the deserialized version of a Recurrence.