### PR TITLE
Introduce Options#start_time

### DIFF
--- a/lib/montrose/clock.rb
+++ b/lib/montrose/clock.rb
@@ -6,8 +6,8 @@ module Montrose
       @options = Montrose::Options.merge(opts)
       @time = nil
       @every = @options.fetch(:every) { fail ConfigurationError, "Required option :every not provided" }
-      @starts = @options.fetch(:starts)
       @interval = @options.fetch(:interval)
+      @start_time = @options.fetch(:start_time)
     end
 
     # Advances time to new unit by increment and sets
@@ -18,7 +18,7 @@ module Montrose
     end
 
     def peek
-      return @starts if @time.nil?
+      return @start_time if @time.nil?
 
       @time.advance(step)
     end

--- a/lib/montrose/frequency.rb
+++ b/lib/montrose/frequency.rb
@@ -45,7 +45,7 @@ module Montrose
     def initialize(opts = {})
       opts = Montrose::Options.merge(opts)
       @time = nil
-      @starts = opts.fetch(:starts)
+      @starts = opts.fetch(:start_time)
       @interval = opts.fetch(:interval)
     end
 

--- a/lib/montrose/rule/time_of_day.rb
+++ b/lib/montrose/rule/time_of_day.rb
@@ -16,17 +16,13 @@ module Montrose
       end
 
       def include?(time)
-        times_of_day.include?(parts(time))
+        @times.include?(parts(time))
       end
 
       private
 
       def parts(time)
         [time.hour, time.min]
-      end
-
-      def times_of_day
-        @times_of_day ||= @times.map { |t| parts(t) }
       end
     end
   end

--- a/lib/montrose/utils.rb
+++ b/lib/montrose/utils.rb
@@ -5,6 +5,23 @@ module Montrose
     MONTHS = Date::MONTHNAMES
     DAYS = Date::DAYNAMES
 
+    def as_time(time)
+      return nil unless time
+
+      case
+      when time.is_a?(String)
+        Time.parse(time)
+      when time.respond_to?(:to_time)
+        time.to_time
+      else
+        Array(time).flat_map { |d| as_time(d) }
+      end
+    end
+
+    def as_date(time)
+      as_time(time).to_date
+    end
+
     def month_number(name)
       case name
       when Symbol, String

--- a/spec/montrose/recurrence_spec.rb
+++ b/spec/montrose/recurrence_spec.rb
@@ -116,6 +116,16 @@ describe Montrose::Recurrence do
         Time.local(2015, 9, 3, 15, 30)
       ]
     end
+
+    it "specifying starts and at option" do
+      recurrence = new_recurrence(every: :week, on: "tuesday", at: "5:00", starts: "2016-06-23")
+
+      recurrence.events.take(3).must_pair_with [
+        Time.local(2016, 6, 28, 5, 00),
+        Time.local(2016, 7, 5,  5, 00),
+        Time.local(2016, 7, 12, 5, 00)
+      ]
+    end
   end
 
   describe "#inspect" do

--- a/spec/montrose/rule/time_of_day_spec.rb
+++ b/spec/montrose/rule/time_of_day_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Montrose::Rule::TimeOfDay do
-  let(:rule) { Montrose::Rule::TimeOfDay.new([Time.parse("9:00 AM"), Time.parse("3:30 PM")]) }
+  let(:rule) { Montrose::Rule::TimeOfDay.new([[9, 0], [15, 30]]) }
 
   describe "#include?" do
     it { assert rule.include?(Time.local(2016, 1, 1, 9)) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ module Minitest
     end
 
     def time_now
-      Time.now
+      Time.now.change(usec: 0)
     end
 
     def consecutive_days(count, starts: time_now, interval: 1)


### PR DESCRIPTION
Changes the internal representation of the `:at` option to represent the
hour and minute parts. Using `:at` no longer sets the `:starts` option
as a side effect. Instead, a new read-only calculated option,
`:start_time` is used internally to represent the logical start of the
recurrence. Using `:starts` and `:at` simultaneously will treat the
`:starts` time as a date and use the first occuring `:at` time of day to
calculate the recurrence start time.

Fixes #42 