### PR TITLE
Respect time zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ Montrose.daily(interval: 2)
 Montrose.every(10.days, total: 5)
 
 # everyday in January for 3 years
-starts = Time.now.beginning_of_year
-ends = Time.now.end_of_year + 2.years
+starts = Time.current.beginning_of_year
+ends = Time.current.end_of_year + 2.years
 Montrose.daily(month: :january, between: starts...ends)
 
 # weekly for 10 occurrences
@@ -356,7 +356,7 @@ Montrose.daily(except: [Date.today, "2017-01-31"])
 # Chaining
 Montrose.weekly.starting(3.weeks.from_now).on(:friday)
 Montrose.every(:day).at("4:05pm")
-Montrose.yearly.between(Time.now..10.years.from_now)
+Montrose.yearly.between(Time.current..10.years.from_now)
 
 # Enumerating events
 r = Montrose.every(:month, mday: 31, until: "January 1, 2017")

--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -6,11 +6,6 @@ module Montrose
     @default_until = nil
     @default_every = nil
 
-    MAX_HOURS_IN_DAY = 24
-    MAX_DAYS_IN_YEAR = 366
-    MAX_WEEKS_IN_YEAR = 53
-    MAX_DAYS_IN_MONTH = 31
-
     class << self
       def new(options = {})
         return options if options.is_a?(self)
@@ -261,19 +256,19 @@ module Montrose
     end
 
     def assert_hour(hour)
-      assert_range_includes(1..MAX_HOURS_IN_DAY, hour)
+      assert_range_includes(1..::Montrose::Utils::MAX_HOURS_IN_DAY, hour)
     end
 
     def assert_mday(mday)
-      assert_range_includes(1..MAX_DAYS_IN_MONTH, mday, :absolute)
+      assert_range_includes(1..::Montrose::Utils::MAX_DAYS_IN_MONTH, mday, :absolute)
     end
 
     def assert_yday(yday)
-      assert_range_includes(1..MAX_DAYS_IN_YEAR, yday, :absolute)
+      assert_range_includes(1..::Montrose::Utils::MAX_DAYS_IN_YEAR, yday, :absolute)
     end
 
     def assert_week(week)
-      assert_range_includes(1..MAX_WEEKS_IN_YEAR, week, :absolute)
+      assert_range_includes(1..::Montrose::Utils::MAX_WEEKS_IN_YEAR, week, :absolute)
     end
 
     def decompose_on_arg(arg)

--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -55,7 +55,7 @@ module Montrose
         when Proc
           @default_starts.call
         when nil
-          Time.now
+          Time.current
         else
           @default_starts
         end

--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -36,7 +36,7 @@ module Montrose
       def default_until
         case @default_until
         when String
-          Time.parse(@default_until)
+          ::Montrose::Utils.parse_time(@default_until)
         when Proc
           @default_until.call
         else
@@ -51,11 +51,11 @@ module Montrose
       def default_starts
         case @default_starts
         when String
-          Time.parse(@default_starts)
+          ::Montrose::Utils.parse_time(@default_starts)
         when Proc
           @default_starts.call
         when nil
-          Time.current
+          ::Montrose::Utils.current_time
         else
           @default_starts
         end

--- a/lib/montrose/rule/day_of_month.rb
+++ b/lib/montrose/rule/day_of_month.rb
@@ -23,7 +23,7 @@ module Montrose
 
       # matches days specified at negative numbers
       def included_from_end_of_month?(time)
-        month_days = Time.days_in_month(time.month, time.year) # given by activesupport
+        month_days = ::Montrose::Utils.days_in_month(time.month, time.year) # given by activesupport
         @days.any? { |d| month_days + d + 1 == time.mday }
       end
     end

--- a/lib/montrose/rule/day_of_year.rb
+++ b/lib/montrose/rule/day_of_year.rb
@@ -30,7 +30,7 @@ module Montrose
       # If no year is specified, it will use the current year.
       # https://github.com/rails/rails/pull/22244
       def days_in_year(year)
-        Time.days_in_month(2, year) + 337
+        ::Montrose::Utils.days_in_month(2, year) + 337
       end
     end
   end

--- a/lib/montrose/rule/day_of_year.rb
+++ b/lib/montrose/rule/day_of_year.rb
@@ -22,15 +22,8 @@ module Montrose
       private
 
       def included_from_end_of_month?(time)
-        year_days = days_in_year(time.year) # given by activesupport
+        year_days = ::Montrose::Utils.days_in_year(time.year) # given by activesupport
         @days.any? { |d| year_days + d + 1 == time.yday }
-      end
-
-      # Returns the number of days in the given year.
-      # If no year is specified, it will use the current year.
-      # https://github.com/rails/rails/pull/22244
-      def days_in_year(year)
-        ::Montrose::Utils.days_in_month(2, year) + 337
       end
     end
   end

--- a/lib/montrose/rule/nth_day_of_month.rb
+++ b/lib/montrose/rule/nth_day_of_month.rb
@@ -47,15 +47,7 @@ module Montrose
         end
 
         def total_days
-          days_in_month(@time)
-        end
-
-        private
-
-        # Get the days in the month for +time
-        def days_in_month(time)
-          date = Date.new(time.year, time.month, 1)
-          ((date >> 1) - date).to_i
+          ::Montrose::Utils.days_in_month(@time.month, @time.year)
         end
       end
     end

--- a/lib/montrose/utils.rb
+++ b/lib/montrose/utils.rb
@@ -10,7 +10,7 @@ module Montrose
 
       case
       when time.is_a?(String)
-        Time.parse(time)
+        parse_time(time)
       when time.respond_to?(:to_time)
         time.to_time
       else
@@ -20,6 +20,14 @@ module Montrose
 
     def as_date(time)
       as_time(time).to_date
+    end
+
+    def parse_time(*args)
+      ::Time.zone.nil? ? ::Time.parse(*args) : ::Time.zone.parse(*args)
+    end
+
+    def current_time
+      ::Time.current
     end
 
     def month_number(name)

--- a/lib/montrose/utils.rb
+++ b/lib/montrose/utils.rb
@@ -60,8 +60,16 @@ module Montrose
         "Did not recognize day #{name}, must be one of #{DAYS.inspect}"
     end
 
-    def days_in_month(*args)
-      ::Time.days_in_month(*args)
+    def days_in_month(month, year = current_time.year)
+      date = ::Date.new(year, month, 1)
+      ((date >> 1) - date).to_i
+    end
+
+    # Returns the number of days in the given year.
+    # If no year is specified, it will use the current year.
+    # https://github.com/rails/rails/pull/22244
+    def days_in_year(year)
+      ::Montrose::Utils.days_in_month(2, year) + 337
     end
   end
 end

--- a/lib/montrose/utils.rb
+++ b/lib/montrose/utils.rb
@@ -59,5 +59,9 @@ module Montrose
       day_number(name) or fail ConfigurationError,
         "Did not recognize day #{name}, must be one of #{DAYS.inspect}"
     end
+
+    def days_in_month(*args)
+      ::Time.days_in_month(*args)
+    end
   end
 end

--- a/lib/montrose/utils.rb
+++ b/lib/montrose/utils.rb
@@ -2,8 +2,13 @@ module Montrose
   module Utils
     module_function
 
-    MONTHS = Date::MONTHNAMES
-    DAYS = Date::DAYNAMES
+    MONTHS = ::Date::MONTHNAMES
+    DAYS = ::Date::DAYNAMES
+
+    MAX_HOURS_IN_DAY = 24
+    MAX_DAYS_IN_YEAR = 366
+    MAX_WEEKS_IN_YEAR = 53
+    MAX_DAYS_IN_MONTH = 31
 
     def as_time(time)
       return nil unless time

--- a/spec/montrose/rule/total_spec.rb
+++ b/spec/montrose/rule/total_spec.rb
@@ -6,24 +6,24 @@ describe Montrose::Rule::Total do
 
   describe "#include?" do
     it "is true before advancing" do
+      assert rule.include?(Time.current)
+    end
+
+    it "is true after advancing to the max" do
+      rule.advance!(Time.current)
+      rule.advance!(Time.current)
+      rule.advance!(Time.current)
+
       assert rule.include?(Time.now)
     end
 
     it "is true after advancing to the max" do
-      rule.advance!(Time.now)
-      rule.advance!(Time.now)
-      rule.advance!(Time.now)
+      rule.advance!(Time.current)
+      rule.advance!(Time.current)
+      rule.advance!(Time.current)
+      rule.advance!(Time.current)
 
-      assert rule.include?(Time.now)
-    end
-
-    it "is true after advancing to the max" do
-      rule.advance!(Time.now)
-      rule.advance!(Time.now)
-      rule.advance!(Time.now)
-      rule.advance!(Time.now)
-
-      refute rule.include?(Time.now)
+      refute rule.include?(Time.current)
     end
   end
 

--- a/spec/montrose/utils_spec.rb
+++ b/spec/montrose/utils_spec.rb
@@ -1,52 +1,54 @@
 require "spec_helper"
 
 describe Montrose::Utils do
+  include Montrose::Utils
+
   describe "#month_number" do
-    it { Montrose::Utils.month_number!(:january).must_equal 1 }
-    it { Montrose::Utils.month_number!(:february).must_equal 2 }
-    it { Montrose::Utils.month_number!(:march).must_equal 3 }
-    it { Montrose::Utils.month_number!(:april).must_equal 4 }
-    it { Montrose::Utils.month_number!(:may).must_equal 5 }
-    it { Montrose::Utils.month_number!(:june).must_equal 6 }
-    it { Montrose::Utils.month_number!(:july).must_equal 7 }
-    it { Montrose::Utils.month_number!(:august).must_equal 8 }
-    it { Montrose::Utils.month_number!(:september).must_equal 9 }
-    it { Montrose::Utils.month_number!(:october).must_equal 10 }
-    it { Montrose::Utils.month_number!(:november).must_equal 11 }
-    it { Montrose::Utils.month_number!(:december).must_equal 12 }
-    it { Montrose::Utils.month_number!(1).must_equal 1 }
-    it { Montrose::Utils.month_number!(2).must_equal 2 }
-    it { Montrose::Utils.month_number!(3).must_equal 3 }
-    it { Montrose::Utils.month_number!(4).must_equal 4 }
-    it { Montrose::Utils.month_number!(5).must_equal 5 }
-    it { Montrose::Utils.month_number!(6).must_equal 6 }
-    it { Montrose::Utils.month_number!(7).must_equal 7 }
-    it { Montrose::Utils.month_number!(8).must_equal 8 }
-    it { Montrose::Utils.month_number!(9).must_equal 9 }
-    it { Montrose::Utils.month_number!(10).must_equal 10 }
-    it { Montrose::Utils.month_number!(11).must_equal 11 }
-    it { Montrose::Utils.month_number!(12).must_equal 12 }
-    it { -> { Montrose::Utils.month_number!(:foo) }.must_raise Montrose::ConfigurationError }
-    it { -> { Montrose::Utils.month_number!(0) }.must_raise Montrose::ConfigurationError }
-    it { -> { Montrose::Utils.month_number!(13) }.must_raise Montrose::ConfigurationError }
+    it { month_number!(:january).must_equal 1 }
+    it { month_number!(:february).must_equal 2 }
+    it { month_number!(:march).must_equal 3 }
+    it { month_number!(:april).must_equal 4 }
+    it { month_number!(:may).must_equal 5 }
+    it { month_number!(:june).must_equal 6 }
+    it { month_number!(:july).must_equal 7 }
+    it { month_number!(:august).must_equal 8 }
+    it { month_number!(:september).must_equal 9 }
+    it { month_number!(:october).must_equal 10 }
+    it { month_number!(:november).must_equal 11 }
+    it { month_number!(:december).must_equal 12 }
+    it { month_number!(1).must_equal 1 }
+    it { month_number!(2).must_equal 2 }
+    it { month_number!(3).must_equal 3 }
+    it { month_number!(4).must_equal 4 }
+    it { month_number!(5).must_equal 5 }
+    it { month_number!(6).must_equal 6 }
+    it { month_number!(7).must_equal 7 }
+    it { month_number!(8).must_equal 8 }
+    it { month_number!(9).must_equal 9 }
+    it { month_number!(10).must_equal 10 }
+    it { month_number!(11).must_equal 11 }
+    it { month_number!(12).must_equal 12 }
+    it { -> { month_number!(:foo) }.must_raise Montrose::ConfigurationError }
+    it { -> { month_number!(0) }.must_raise Montrose::ConfigurationError }
+    it { -> { month_number!(13) }.must_raise Montrose::ConfigurationError }
   end
 
   describe "#day_number" do
-    it { Montrose::Utils.day_number!(:sunday).must_equal 0 }
-    it { Montrose::Utils.day_number!(:monday).must_equal 1 }
-    it { Montrose::Utils.day_number!(:tuesday).must_equal 2 }
-    it { Montrose::Utils.day_number!(:wednesday).must_equal 3 }
-    it { Montrose::Utils.day_number!(:thursday).must_equal 4 }
-    it { Montrose::Utils.day_number!(:friday).must_equal 5 }
-    it { Montrose::Utils.day_number!(:saturday).must_equal 6 }
-    it { Montrose::Utils.day_number!(0).must_equal 0 }
-    it { Montrose::Utils.day_number!(1).must_equal 1 }
-    it { Montrose::Utils.day_number!(2).must_equal 2 }
-    it { Montrose::Utils.day_number!(3).must_equal 3 }
-    it { Montrose::Utils.day_number!(4).must_equal 4 }
-    it { Montrose::Utils.day_number!(5).must_equal 5 }
-    it { Montrose::Utils.day_number!(6).must_equal 6 }
-    it { -> { Montrose::Utils.day_number!(-3) }.must_raise Montrose::ConfigurationError }
-    it { -> { Montrose::Utils.day_number!(:foo) }.must_raise Montrose::ConfigurationError }
+    it { day_number!(:sunday).must_equal 0 }
+    it { day_number!(:monday).must_equal 1 }
+    it { day_number!(:tuesday).must_equal 2 }
+    it { day_number!(:wednesday).must_equal 3 }
+    it { day_number!(:thursday).must_equal 4 }
+    it { day_number!(:friday).must_equal 5 }
+    it { day_number!(:saturday).must_equal 6 }
+    it { day_number!(0).must_equal 0 }
+    it { day_number!(1).must_equal 1 }
+    it { day_number!(2).must_equal 2 }
+    it { day_number!(3).must_equal 3 }
+    it { day_number!(4).must_equal 4 }
+    it { day_number!(5).must_equal 5 }
+    it { day_number!(6).must_equal 6 }
+    it { -> { day_number!(-3) }.must_raise Montrose::ConfigurationError }
+    it { -> { day_number!(:foo) }.must_raise Montrose::ConfigurationError }
   end
 end

--- a/spec/montrose/utils_spec.rb
+++ b/spec/montrose/utils_spec.rb
@@ -3,6 +3,20 @@ require "spec_helper"
 describe Montrose::Utils do
   include Montrose::Utils
 
+  describe "#parse_time" do
+    it { parse_time("Sept 1, 2015 12:00PM").must_equal Time.parse("Sept 1, 2015 12:00PM") }
+    it "uses Time.zone if available" do
+      Time.use_zone("Hawaii") do
+        time = parse_time("Sept 1, 2015 12:00PM")
+        time.month.must_equal 9
+        time.day.must_equal 1
+        time.year.must_equal 2015
+        time.hour.must_equal 12
+        time.utc_offset.must_equal(-10.hours)
+      end
+    end
+  end
+
   describe "#month_number" do
     it { month_number!(:january).must_equal 1 }
     it { month_number!(:february).must_equal 2 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ module Minitest
     end
 
     def time_now
-      Time.now.change(usec: 0)
+      Time.current.change(usec: 0)
     end
 
     def consecutive_days(count, starts: time_now, interval: 1)


### PR DESCRIPTION
Time parsing and current time should respect `Time.zone` when configured.

Fixes #8 