### PR TITLE
Implement Recurrence#to_json

### DIFF
--- a/lib/montrose/recurrence.rb
+++ b/lib/montrose/recurrence.rb
@@ -62,6 +62,15 @@ module Montrose
     end
     alias to_h to_hash
 
+    # Returns json string of options used to create
+    # the recurrence
+    #
+    # @return [String] json of recurrence options
+    #
+    def to_json
+      to_hash.to_json
+    end
+
     def inspect
       "#<#{self.class}:#{object_id.to_s(16)} #{to_h.inspect}>"
     end

--- a/spec/montrose/recurrence_spec.rb
+++ b/spec/montrose/recurrence_spec.rb
@@ -142,10 +142,19 @@ describe Montrose::Recurrence do
     let(:now) { time_now }
     let(:recurrence) { new_recurrence(every: :month, starts: now, interval: 1) }
 
-    it do
+    it "is readable" do
       inspected = "#<Montrose::Recurrence:#{recurrence.object_id.to_s(16)} "
       inspected << "{:every=>:month, :starts=>#{now.inspect}, :interval=>1}>"
       recurrence.inspect.must_equal inspected
+    end
+  end
+
+  describe "#to_json" do
+    it "returns json string of its options" do
+      options = { every: :day, at: "3:45pm" }
+      recurrence = new_recurrence(options)
+
+      recurrence.to_json.must_equal "{\"every\":\"day\",\"at\":[[15,45]]}"
     end
   end
 end


### PR DESCRIPTION
Delegates to Recurrence#to_hash. Fixes bug where #to_json would get
stuck in an infinite loop due to default behavior imposed by
ActiveSupport

Fixes #34 