### PR TITLE
Respect TimeWithZone objects passed into as_time during assignment

### DIFF
--- a/lib/montrose/frequency/weekly.rb
+++ b/lib/montrose/frequency/weekly.rb
@@ -2,7 +2,7 @@ module Montrose
   class Frequency
     class Weekly < Frequency
       def include?(time)
-        weeks_since_start(time) % @interval == 0
+        (weeks_since_start(time) % @interval).zero?
       end
 
       private

--- a/lib/montrose/utils.rb
+++ b/lib/montrose/utils.rb
@@ -15,6 +15,8 @@ module Montrose
 
       if time.is_a?(String)
         parse_time(time)
+      elsif time.is_a?(ActiveSupport::TimeWithZone)
+        time
       elsif time.respond_to?(:to_time)
         time.to_time
       else

--- a/spec/montrose/utils_spec.rb
+++ b/spec/montrose/utils_spec.rb
@@ -9,6 +9,26 @@ describe Montrose::Utils do
     end
   end
 
+  describe "#as_time" do
+    it "parses Strings" do
+      time_string = Time.now.to_s
+      as_time(time_string).class.must_equal Time
+      as_time(time_string).must_equal Time.parse(time_string)
+    end
+
+    it "returns unmodified ActiveSupport::TimeWithZone objects" do
+      Time.use_zone("Beijing") do
+        time_with_zone = Time.zone.now
+        time_with_zone.class.must_equal ActiveSupport::TimeWithZone
+        as_time(time_with_zone).must_equal time_with_zone
+      end
+    end
+
+    it "casts to_time if available" do
+      as_time(Date.today).must_equal Date.today.to_time
+    end
+  end
+
   describe "#parse_time" do
     it { parse_time("Sept 1, 2015 12:00PM").must_equal Time.parse("Sept 1, 2015 12:00PM") }
     it "uses Time.zone if available" do


### PR DESCRIPTION
When working with start and end dates, `ActiveSupport::TimeWithZone` objects passed in are being converted using `to_time` which leads to some undesired behavior calculating recurrences.  Passing a string doesn't solve the issue due to [this](https://github.com/rossta/montrose/blob/master/lib/montrose/recurrence.rb#L81) `Options.merge` call leading to the parsed TimeWithZone object being passed back into `as_time` and then converted `to_time`.

**Current behavior**
```ruby
Montrose.r(every: "month").events.first
=> Wed, 27 Jul 2016 09:14:59 UTC +00:00
Montrose.r(every: "month", starts: Time.zone.now).events.first
=> "2016-07-27T04:15:48.606-05:00"
Montrose.r(every: "month", starts: Time.zone.now.to_s).events.first
=> "2016-07-27T04:21:48.000-05:00"
```
**New behavior**
```ruby
Montrose.r(every: "month").events.first
=> Wed, 27 Jul 2016 09:17:20 UTC +00:00
Montrose.r(every: "month", starts: Time.zone.now).events.first
=> Wed, 27 Jul 2016 09:17:22 UTC +00:00
```

We now get ActiveSupport::TimeWIthZone events when using and not using a start date, vs the prior inconsistent behavior.