### PR TITLE
Bug fix recurrence include

### DIFF
--- a/lib/montrose/recurrence.rb
+++ b/lib/montrose/recurrence.rb
@@ -82,7 +82,7 @@ module Montrose
     # Return true/false if given timestamp equals a
     # timestamp given by the recurrence
     #
-    # @return [Boolean] timestamp is included in recurrence
+    # @return [Boolean] whether or not timestamp is included in recurrence
     #
     def include?(timestamp)
       return false if earlier?(timestamp) || later?(timestamp)
@@ -95,15 +95,28 @@ module Montrose
       end or false
     end
 
-    # Return true/false if given timestamp equals
+    # Return true/false if recurrence will iterate infinitely
+    #
+    # @return [Boolean] whether or not recurrence is infinite
+    #
     def finite?
       ends_at || length
     end
 
+    # Return true/false if given timestamp occurs before
+    # the recurrence
+    #
+    # @return [Boolean] whether or not timestamp is earlier
+    #
     def earlier?(timestamp)
       starts_at && timestamp < starts_at
     end
 
+    # Return true/false if given timestamp occurs after
+    # the recurrence
+    #
+    # @return [Boolean] whether or not timestamp is later
+    #
     def later?(timestamp)
       ends_at && timestamp > ends_at
     end

--- a/spec/montrose/recurrence_spec.rb
+++ b/spec/montrose/recurrence_spec.rb
@@ -190,10 +190,18 @@ describe Montrose::Recurrence do
       refute recurrence.include?(timestamp)
     end
 
-    it "is false if falls outside finite range by date" do
+    it "is false if falls after finite range by date" do
       recurrence = new_recurrence(every: :day).at("3:30 PM").ending(10.days.from_now)
 
       timestamp = 11.days.from_now.beginning_of_day.advance(hours: 15, minutes: 30)
+
+      refute recurrence.include?(timestamp)
+    end
+
+    it "is false if falls before finite range by date" do
+      recurrence = new_recurrence(every: :day).at("3:30 PM").starts(1.day.from_now)
+
+      timestamp = Time.now.beginning_of_day.advance(hours: 15, minutes: 30)
 
       refute recurrence.include?(timestamp)
     end


### PR DESCRIPTION
`Recurrence#include?` optimization introduced bug where given timestamp occurring before the start point of a recurrence (if it exists) could return true.