### PR TITLE
Remove :between from defined options

### DIFF
--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -79,7 +79,6 @@ module Montrose
     def_option :month
     def_option :interval
     def_option :total
-    def_option :between
     def_option :at
     def_option :on
     def_option :except

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,9 @@
+require "simplecov"
 require "coveralls"
-Coveralls.wear! do
+SimpleCov.maximum_coverage_drop 5
+SimpleCov.start do
   add_filter "bundle|gemfiles|spec|vendor"
 end
-SimpleCov.maximum_coverage_drop 5
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "montrose"


### PR DESCRIPTION
Creates duplication with already-present :starts and :until options