### PR TITLE
Handle nil for deserialization in Recurrence.load

### DIFF
--- a/lib/montrose/recurrence.rb
+++ b/lib/montrose/recurrence.rb
@@ -233,6 +233,8 @@ module Montrose
       end
 
       def load(json)
+        return nil if json.nil?
+
         new JSON.parse(json)
       end
     end

--- a/spec/montrose/recurrence_spec.rb
+++ b/spec/montrose/recurrence_spec.rb
@@ -99,6 +99,12 @@ describe Montrose::Recurrence do
       default_options[:starts].to_i.must_equal now.to_i
       default_options[:interval].must_equal 1
     end
+
+    it "returns nil for nil dump" do
+      loaded = Montrose::Recurrence.load(nil)
+
+      loaded.must_be_nil
+    end
   end
 
   describe "integration specs" do


### PR DESCRIPTION
When calling `Montrose::Recurrence.load(nil)`, let's avoid a `TypeError`, ex:

```
TypeError: no implicit conversion of nil into String
    .../ruby/2.2.3/gems/json-2.0.2/lib/json/common.rb:156:in `initialize'
    .../ruby/2.2.3/gems/json-2.0.2/lib/json/common.rb:156:in `new'
    .../ruby/2.2.3/gems/json-2.0.2/lib/json/common.rb:156:in `parse'
    .../montrose/lib/montrose/recurrence.rb:236:in `load'
```