### PR TITLE
Handle JSON in Recurrence.dump

### DIFF
--- a/lib/montrose/recurrence.rb
+++ b/lib/montrose/recurrence.rb
@@ -224,6 +224,9 @@ module Montrose
 
       def dump(obj)
         return nil if obj.nil?
+
+        obj = load(obj) if obj.is_a?(String)
+
         unless obj.is_a?(self)
           fail SerializationError,
             "Object was supposed to be a #{self}, but was a #{obj.class}. -- #{obj.inspect}"
@@ -236,6 +239,8 @@ module Montrose
         return nil if json.nil?
 
         new JSON.parse(json)
+      rescue JSON::ParserError => e
+        fail SerializationError, "Could not parse JSON: #{e}"
       end
     end
 

--- a/spec/montrose/recurrence_spec.rb
+++ b/spec/montrose/recurrence_spec.rb
@@ -77,11 +77,26 @@ describe Montrose::Recurrence do
       parsed[:starts].must_equal now.to_s
     end
 
-    it "raises error if not a self" do
-      -> { Montrose::Recurrence.dump(Object.new) }.must_raise Montrose::SerializationError
+    it "accepts json string" do
+      str = { every: :day, total: 3, starts: now, interval: 1 }.to_json
+
+      dump = Montrose::Recurrence.dump(str)
+      parsed = JSON.parse(dump).symbolize_keys
+      parsed[:every].must_equal "day"
+      parsed[:total].must_equal 3
+      parsed[:interval].must_equal 1
+      parsed[:starts].must_equal now.to_s
     end
 
     it { Montrose::Recurrence.dump(nil).must_be_nil }
+
+    it "raises error if str not parseable as JSON" do
+      -> { Montrose::Recurrence.dump("foo") }.must_raise Montrose::SerializationError
+    end
+
+    it "raises error otherwise" do
+      -> { Montrose::Recurrence.dump(Object.new) }.must_raise Montrose::SerializationError
+    end
   end
 
   describe ".load" do


### PR DESCRIPTION
The following raises an error:

```ruby
Montrose::Recurrence.dump(every: :day)
```

This successfully serialize the recurrence options. Later we can validate the hash.

