### PR TITLE
Handle dump of hash for Recurrence serialization

### DIFF
--- a/lib/montrose/recurrence.rb
+++ b/lib/montrose/recurrence.rb
@@ -224,15 +224,19 @@ module Montrose
 
       def dump(obj)
         return nil if obj.nil?
+        return dump(load(obj)) if obj.is_a?(String)
 
-        obj = load(obj) if obj.is_a?(String)
+        hash = case obj
+               when Hash
+                 obj
+               when self
+                 obj.to_hash
+               else
+                 fail SerializationError,
+                   "Object was supposed to be a #{self}, but was a #{obj.class}. -- #{obj.inspect}"
+               end
 
-        unless obj.is_a?(self)
-          fail SerializationError,
-            "Object was supposed to be a #{self}, but was a #{obj.class}. -- #{obj.inspect}"
-        end
-
-        JSON.dump(obj.to_hash)
+        JSON.dump(hash)
       end
 
       def load(json)

--- a/spec/montrose/recurrence_spec.rb
+++ b/spec/montrose/recurrence_spec.rb
@@ -77,11 +77,23 @@ describe Montrose::Recurrence do
       parsed[:starts].must_equal now.to_s
     end
 
+    it "accepts json hash" do
+      hash = { every: :day, total: 3, starts: now, interval: 1 }
+
+      dump = Montrose::Recurrence.dump(hash)
+      parsed = JSON.parse(dump).symbolize_keys
+      parsed[:every].must_equal "day"
+      parsed[:total].must_equal 3
+      parsed[:interval].must_equal 1
+      parsed[:starts].must_equal now.to_s
+    end
+
     it "accepts json string" do
       str = { every: :day, total: 3, starts: now, interval: 1 }.to_json
 
       dump = Montrose::Recurrence.dump(str)
       parsed = JSON.parse(dump).symbolize_keys
+
       parsed[:every].must_equal "day"
       parsed[:total].must_equal 3
       parsed[:interval].must_equal 1


### PR DESCRIPTION
The following raises an error:

```ruby
Montrose::Recurrence.dump(every: :day)
```

This successfully serialize the recurrence options. Later we can validate the hash.