### PR TITLE
Handle blank object in Recurrence.load

### DIFF
--- a/lib/montrose/recurrence.rb
+++ b/lib/montrose/recurrence.rb
@@ -240,7 +240,7 @@ module Montrose
       end
 
       def load(json)
-        return nil if json.nil?
+        return nil if json.blank?
 
         new JSON.parse(json)
       rescue JSON::ParserError => e

--- a/spec/montrose/recurrence_spec.rb
+++ b/spec/montrose/recurrence_spec.rb
@@ -132,6 +132,12 @@ describe Montrose::Recurrence do
 
       loaded.must_be_nil
     end
+
+    it "returns nil for empty dump" do
+      loaded = Montrose::Recurrence.load("")
+
+      loaded.must_be_nil
+    end
   end
 
   describe "integration specs" do


### PR DESCRIPTION
We should be able to handle

```ruby
Montrose::Recurrence.load("") # => nil
```

Currently throws a JSON parse error.