### PR TITLE
Ensure latest version of rubygems on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ rvm:
   - 2.2.6
   - 2.3.3
 sudo: false
+before_install:
+  - gem update --system
+  - gem --version


### PR DESCRIPTION
Installation of rainbow failing for ruby 2.3. See
https://github.com/sickill/rainbow/issues/44