### PR TITLE
Add separate filter for :between option

### DIFF
--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -72,6 +72,7 @@ module Montrose
     def_option :every
     def_option :starts
     def_option :until
+    def_option :between
     def_option :hour
     def_option :day
     def_option :mday
@@ -183,14 +184,9 @@ module Montrose
     end
 
     def between=(range)
-      self[:starts] = range.first
-      self[:until] = range.last
-    end
-
-    def between
-      return nil unless self[:starts] && self[:until]
-
-      (self[:starts]..self[:until])
+      @between = range
+      self[:starts] = range.first unless self[:starts]
+      self[:until] = range.last unless self[:until]
     end
 
     def at=(time)

--- a/lib/montrose/rule.rb
+++ b/lib/montrose/rule.rb
@@ -14,7 +14,7 @@ module Montrose
       true
     end
 
-    def continue?
+    def continue?(_time = nil)
       true
     end
 
@@ -36,6 +36,7 @@ end
 
 require "montrose/rule/after"
 require "montrose/rule/before"
+require "montrose/rule/between"
 require "montrose/rule/day_of_month"
 require "montrose/rule/day_of_week"
 require "montrose/rule/day_of_year"

--- a/lib/montrose/rule/after.rb
+++ b/lib/montrose/rule/after.rb
@@ -20,7 +20,7 @@ module Montrose
         time >= @start_time
       end
 
-      def continue?
+      def continue?(_time)
         false
       end
     end

--- a/lib/montrose/rule/before.rb
+++ b/lib/montrose/rule/before.rb
@@ -16,7 +16,7 @@ module Montrose
         time < @end_time
       end
 
-      def continue?
+      def continue?(_time)
         false
       end
     end

--- a/lib/montrose/rule/between.rb
+++ b/lib/montrose/rule/between.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module Montrose
+  module Rule
+    class Between
+      include Montrose::Rule
+
+      def self.apply_options(opts)
+        opts[:between].is_a?(Range) && opts[:between]
+      end
+
+      # Initializes rule
+      #
+      # @param [Range] between - timestamp range
+      #
+      def initialize(between)
+        @between = between
+      end
+
+      def include?(time)
+        @between.cover?(time)
+      end
+
+      def continue?(time)
+        @between.max > time
+      end
+    end
+  end
+end

--- a/lib/montrose/rule/total.rb
+++ b/lib/montrose/rule/total.rb
@@ -13,16 +13,16 @@ module Montrose
         @count = 0
       end
 
-      def include?(_time)
-        continue?
+      def include?(time)
+        continue?(time)
       end
 
-      def advance!(_time)
+      def advance!(time)
         @count += 1
-        continue?
+        continue?(time)
       end
 
-      def continue?
+      def continue?(_time)
         @count <= @max
       end
     end

--- a/lib/montrose/stack.rb
+++ b/lib/montrose/stack.rb
@@ -12,6 +12,7 @@ module Montrose
         Frequency,
         Rule::After,
         Rule::Before,
+        Rule::Between,
         Rule::Except,
         Rule::Total,
         Rule::TimeOfDay,
@@ -46,7 +47,7 @@ module Montrose
         yield time if block_given?
         true
       else
-        no.any?(&:continue?)
+        no.any? { |rule| rule.continue?(time) }
       end
     end
   end

--- a/spec/montrose/options_spec.rb
+++ b/spec/montrose/options_spec.rb
@@ -322,7 +322,21 @@ describe Montrose::Options do
     it "returns given date range" do
       options[:between] = Date.today..1.month.from_now.to_date
 
-      options.between.must_equal(Date.today.to_time..1.month.from_now.beginning_of_day)
+      options.between.must_equal(Date.today..1.month.from_now.to_date)
+    end
+
+    it "defers to separate starts time outside of range" do
+      options[:between] = Date.today..1.month.from_now.to_date
+      options[:starts] = 1.day.ago
+
+      options.starts.must_equal 1.day.ago.to_time
+    end
+
+    it "defers to separate starts time within range" do
+      options[:between] = Date.today..1.month.from_now.to_date
+      options[:starts] = 1.day.from_now
+
+      options.starts.must_equal 1.day.from_now.to_time
     end
   end
 

--- a/spec/montrose/recurrence_spec.rb
+++ b/spec/montrose/recurrence_spec.rb
@@ -162,9 +162,9 @@ describe Montrose::Recurrence do
       recurrence = new_recurrence(every: :week, on: "tuesday", at: "5:00", starts: "2016-06-23")
 
       recurrence.events.take(3).must_pair_with [
-        Time.local(2016, 6, 28, 5, 0o0),
-        Time.local(2016, 7, 5,  5, 0o0),
-        Time.local(2016, 7, 12, 5, 0o0)
+        Time.local(2016, 6, 28, 5, 0),
+        Time.local(2016, 7, 5,  5, 0),
+        Time.local(2016, 7, 12, 5, 0)
       ]
     end
 
@@ -172,9 +172,21 @@ describe Montrose::Recurrence do
       recurrence = new_recurrence(every: :day, at: ["7:00am", "3:30pm"])
 
       recurrence.events.take(3).must_pair_with [
-        Time.local(2015, 9, 1, 7,  0o0),
+        Time.local(2015, 9, 1, 7,  0),
         Time.local(2015, 9, 1, 15, 30),
-        Time.local(2015, 9, 2, 7,  0o0)
+        Time.local(2015, 9, 2, 7,  0)
+      ]
+    end
+
+    it "anchors to starts time outside of between range" do
+      recurrence = new_recurrence(every: :day,
+                                  interval: 3,
+                                  starts: 1.day.ago,
+                                  between: Date.today..7.days.from_now)
+
+      recurrence.events.to_a.must_pair_with [
+        Time.local(2015, 9, 3, 12),
+        Time.local(2015, 9, 6, 12)
       ]
     end
   end

--- a/spec/montrose/rule/after_spec.rb
+++ b/spec/montrose/rule/after_spec.rb
@@ -11,6 +11,6 @@ describe Montrose::Rule::After do
   end
 
   describe "#continue?" do
-    it { refute rule.continue? }
+    it { refute rule.continue?(time_now) }
   end
 end

--- a/spec/montrose/rule/before_spec.rb
+++ b/spec/montrose/rule/before_spec.rb
@@ -11,6 +11,6 @@ describe Montrose::Rule::Before do
   end
 
   describe "#continue?" do
-    it { refute rule.continue? }
+    it { refute rule.continue?(time_now) }
   end
 end

--- a/spec/montrose/rule/between_spec.rb
+++ b/spec/montrose/rule/between_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Montrose::Rule::Between do
+  let(:rule) { Montrose::Rule::Between.new(1.day.ago..3.days.from_now) }
+
+  describe "#include?" do
+    it { refute rule.include?(time_now - 10.days) }
+    it { assert rule.include?(time_now) }
+    it { refute rule.include?(time_now + 10.days) }
+  end
+
+  describe "#continue?" do
+    it { assert rule.continue?(time_now - 10.days) }
+    it { assert rule.continue?(time_now) }
+    it { refute rule.continue?(time_now + 10.days) }
+  end
+end

--- a/spec/montrose/rule/day_of_month_spec.rb
+++ b/spec/montrose/rule/day_of_month_spec.rb
@@ -16,6 +16,6 @@ describe Montrose::Rule::DayOfMonth do
   end
 
   describe "#continue?" do
-    it { assert rule.continue? }
+    it { assert rule.continue?(time_now) }
   end
 end

--- a/spec/montrose/rule/day_of_week_spec.rb
+++ b/spec/montrose/rule/day_of_week_spec.rb
@@ -15,6 +15,6 @@ describe Montrose::Rule::DayOfWeek do
   end
 
   describe "#continue?" do
-    it { assert rule.continue? }
+    it { assert rule.continue?(time_now) }
   end
 end

--- a/spec/montrose/rule/total_spec.rb
+++ b/spec/montrose/rule/total_spec.rb
@@ -29,6 +29,6 @@ describe Montrose::Rule::Total do
   end
 
   describe "#continue?" do
-    it { assert rule.continue? }
+    it { assert rule.continue?(time_now) }
   end
 end


### PR DESCRIPTION
Previously, the `:between` option served as a shorthand for `:starts` to `:until`. Now, when both `:starts` and `:between` are provided, the recurrence will behave as if anchored by the given `:starts` option, but filtered through the given `:betweeen` option. 

Fixes #82 