### PR TITLE
Bump activesupport version

### DIFF
--- a/montrose.gemspec
+++ b/montrose.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.1.0"
 
-  spec.add_dependency "activesupport", ">= 4.1", "< 5.1"
+  spec.add_dependency "activesupport", ">= 4.1", "< 5.2"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "appraisal", "~> 2.1.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,7 +94,7 @@ module Minitest
     def assert_interval(actual_duration, given_enum)
       first = given_enum.next
       second = given_enum.next
-      assert_equal actual_duration.to_i, (second - first).to_i
+      assert_equal first + actual_duration, second
     end
 
     def assert_tick(actual_duration, clock)


### PR DESCRIPTION
The specs pass on activesupport 5.1 so there's no reason not to allow it.