### PR TITLE
Adding to_cron method to Frequency

### DIFF
--- a/lib/montrose/frequency.rb
+++ b/lib/montrose/frequency.rb
@@ -55,6 +55,16 @@ module Montrose
     def matches_interval?(time_diff)
       (time_diff % @interval).zero?
     end
+
+    def to_cron
+      raise "abstract"
+    end
+
+    protected
+
+    def interval_str
+      @interval != 1 ? "*/#{@interval}" : "*"
+    end
   end
 end
 

--- a/lib/montrose/frequency/daily.rb
+++ b/lib/montrose/frequency/daily.rb
@@ -6,6 +6,10 @@ module Montrose
       def include?(time)
         matches_interval? time.to_date - @starts.to_date
       end
+
+      def to_cron
+        "#{@starts.min} #{@starts.hour} #{interval_str} * *"
+      end
     end
   end
 end

--- a/lib/montrose/frequency/hourly.rb
+++ b/lib/montrose/frequency/hourly.rb
@@ -6,6 +6,10 @@ module Montrose
       def include?(time)
         matches_interval?((time - @starts) / 1.hour)
       end
+
+      def to_cron
+        "#{@starts.min} #{interval_str} * * *"
+      end
     end
   end
 end

--- a/lib/montrose/frequency/monthly.rb
+++ b/lib/montrose/frequency/monthly.rb
@@ -6,6 +6,10 @@ module Montrose
       def include?(time)
         matches_interval?((time.month - @starts.month) + (time.year - @starts.year) * 12)
       end
+
+      def to_cron
+        "#{@starts.min} #{@starts.hour} #{@starts.day} #{interval_str} *"
+      end
     end
   end
 end

--- a/lib/montrose/frequency/weekly.rb
+++ b/lib/montrose/frequency/weekly.rb
@@ -7,6 +7,11 @@ module Montrose
         (weeks_since_start(time) % @interval).zero?
       end
 
+      def to_cron
+        raise "Intervals unsupported" unless @interval == 1
+        "#{@starts.min} #{@starts.hour} * * #{@starts.wday}"
+      end
+
       private
 
       def weeks_since_start(time)

--- a/lib/montrose/frequency/yearly.rb
+++ b/lib/montrose/frequency/yearly.rb
@@ -6,6 +6,11 @@ module Montrose
       def include?(time)
         matches_interval? time.year - @starts.year
       end
+
+      def to_cron
+        raise "Intervals unsupported" unless @interval == 1
+        "#{@starts.min} #{@starts.hour} #{@starts.day} #{@starts.month} *"
+      end
     end
   end
 end

--- a/spec/montrose/frequency/daily_spec.rb
+++ b/spec/montrose/frequency/daily_spec.rb
@@ -33,4 +33,20 @@ describe Montrose::Frequency::Daily do
       refute frequency.include? now + 3.days
     end
   end
+
+  describe "#to_cron" do
+    let(:now) { Time.new(2018, 5, 31, 16, 30, 0) }
+
+    it "returns a valid crontab entry with no interval" do
+      frequency = new_frequency(every: :day)
+
+      assert_equal frequency.to_cron, "30 16 * * *"
+    end
+
+    it "returns a valid crontab entry with days interval" do
+      frequency = new_frequency(every: :day, interval: 2)
+
+      assert_equal frequency.to_cron, "30 16 */2 * *"
+    end
+  end
 end

--- a/spec/montrose/frequency/hourly_spec.rb
+++ b/spec/montrose/frequency/hourly_spec.rb
@@ -42,4 +42,20 @@ describe Montrose::Frequency::Hourly do
       refute frequency.include? now + 10.hours + 3.minutes
     end
   end
+
+  describe "#to_cron" do
+    let(:now) { Time.new(2018, 5, 31, 16, 30, 0) }
+
+    it "returns a valid crontab with no interval" do
+      frequency = new_frequency(every: :hour)
+
+      assert_equal frequency.to_cron, "30 * * * *"
+    end
+
+    it "returns a valid crontab with an interval" do
+      frequency = new_frequency(every: :hour, interval: 3)
+
+      assert_equal frequency.to_cron, "30 */3 * * *"
+    end
+  end
 end

--- a/spec/montrose/frequency/monthly_spec.rb
+++ b/spec/montrose/frequency/monthly_spec.rb
@@ -33,4 +33,20 @@ describe Montrose::Frequency::Monthly do
       refute frequency.include? now + 3.months
     end
   end
+
+  describe "#to_cron" do
+    let(:now) { Time.new(2018, 5, 31, 16, 30, 0) }
+
+    it "returns a valid crontab with no interval" do
+      frequency = new_frequency(every: :month)
+
+      assert_equal frequency.to_cron, "30 16 31 * *"
+    end
+
+    it "returns a valid crontab with an interval" do
+      frequency = new_frequency(every: :month, interval: 4)
+
+      assert_equal frequency.to_cron, "30 16 31 */4 *"
+    end
+  end
 end

--- a/spec/montrose/frequency/weekly_spec.rb
+++ b/spec/montrose/frequency/weekly_spec.rb
@@ -33,4 +33,20 @@ describe Montrose::Frequency::Weekly do
       refute frequency.include? now + 3.weeks
     end
   end
+
+  describe "#to_cron" do
+    let(:now) { Time.new(2018, 5, 31, 16, 30, 0) }
+
+    it "returns a valid crontab with no interval" do
+      frequency = new_frequency(every: :week)
+
+      assert_equal frequency.to_cron, "30 16 * * #{now.wday}"
+    end
+
+    it "raises on a non-weekly interval" do
+      frequency = new_frequency(every: :week, interval: 2)
+
+      assert_raises(RuntimeError) { frequency.to_cron }
+    end
+  end
 end

--- a/spec/montrose/frequency/yearly_spec.rb
+++ b/spec/montrose/frequency/yearly_spec.rb
@@ -33,4 +33,19 @@ describe Montrose::Frequency::Yearly do
       refute frequency.include? now + 3.years
     end
   end
+  describe "#to_cron" do
+    let(:now) { Time.new(2018, 5, 31, 16, 30, 0) }
+
+    it "returns a valid crontab with no interval" do
+      frequency = new_frequency(every: :year)
+
+      assert_equal frequency.to_cron, "30 16 31 5 *"
+    end
+
+    it "raises on non-yearly interval" do
+      frequency = new_frequency(every: :year, interval: 3)
+
+      assert_raises(RuntimeError) { frequency.to_cron }
+    end
+  end
 end


### PR DESCRIPTION
I use this gem to save some recurring events in a database. Sometimes I need to generate a crontab from a list of these recurrences, for which these shortcuts are handy. 

I understand this may have some caveats given the unspecified behavior of crontab extensions. Still, I assume this is a common enough scenario for users of this gem, so please consider including this.

To use them, one can do the following:

```ruby
recurrence = # retrieve Montrose::Recurrence object here
Montrose::Frequency.from_options(recurrence.to_h).to_cron # generates cron entry
```