### PR TITLE
Bug fix: nth day of week in month in yearly interval

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,12 +39,6 @@ Metrics/BlockLength:
 Documentation:
   Enabled: false # TODO: Enable again once we have more docs
 
-Lint/EndAlignment:
-  Enabled: false
-
-Lint/DefEndAlignment:
-  Enabled: false
-
 Lint/HandleExceptions:
   Enabled: false
 
@@ -80,6 +74,12 @@ Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
 Layout/ClosingParenthesisIndentation:
+  Enabled: false
+
+Layout/EndAlignment:
+  Enabled: false
+
+Layout/DefEndAlignment:
   Enabled: false
 
 Style/OneLineConditional:

--- a/lib/montrose/frequency/weekly.rb
+++ b/lib/montrose/frequency/weekly.rb
@@ -9,6 +9,7 @@ module Montrose
 
       def to_cron
         raise "Intervals unsupported" unless @interval == 1
+
         "#{@starts.min} #{@starts.hour} * * #{@starts.wday}"
       end
 

--- a/lib/montrose/frequency/yearly.rb
+++ b/lib/montrose/frequency/yearly.rb
@@ -9,6 +9,7 @@ module Montrose
 
       def to_cron
         raise "Intervals unsupported" unless @interval == 1
+
         "#{@starts.min} #{@starts.hour} #{@starts.day} #{@starts.month} *"
       end
     end

--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -11,6 +11,7 @@ module Montrose
     class << self
       def new(options = {})
         return options if options.is_a?(self)
+
         super
       end
 
@@ -142,6 +143,7 @@ module Montrose
 
     def fetch(key, *args, &_block)
       fail ArgumentError, "wrong number of arguments (#{args.length} for 1..2)" if args.length > 1
+
       found = send(key)
       return found if found
       return args.first if args.length == 1
@@ -305,8 +307,10 @@ module Montrose
     def month_or_day(key)
       month = month_number(key)
       return [:month, month] if month
+
       day = day_number(key)
       return [:day, day] if day
+
       fail ConfigurationError, "Did not recognize #{key} as a month or day"
     end
 

--- a/lib/montrose/recurrence.rb
+++ b/lib/montrose/recurrence.rb
@@ -222,6 +222,7 @@ module Montrose
     class << self
       def new(options = {})
         return options if options.is_a?(self)
+
         super
       end
 

--- a/lib/montrose/rule/nth_day_of_month.rb
+++ b/lib/montrose/rule/nth_day_of_month.rb
@@ -8,7 +8,7 @@ module Montrose
       include Montrose::Rule
 
       def self.apply_options?(opts)
-        opts[:every] == :month && opts[:day].is_a?(Hash)
+        (opts[:every] == :month || opts[:month]) && opts[:day].is_a?(Hash)
       end
 
       def self.apply_options(opts)

--- a/lib/montrose/rule/nth_day_of_year.rb
+++ b/lib/montrose/rule/nth_day_of_year.rb
@@ -8,7 +8,7 @@ module Montrose
       include Montrose::Rule
 
       def self.apply_options?(opts)
-        opts[:every] == :year && opts[:day].is_a?(Hash)
+        opts[:every] == :year && !opts[:month] && opts[:day].is_a?(Hash)
       end
 
       def self.apply_options(opts)

--- a/montrose.gemspec
+++ b/montrose.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "appraisal", "~> 2.2.0"
   spec.add_development_dependency "m", "~> 1.5"
-  spec.add_development_dependency "minitest", "~> 5.10"
+  spec.add_development_dependency "minitest"
   spec.add_development_dependency "rake", "~> 11.0"
   spec.add_development_dependency "rubocop", "~> 0.64.0"
   spec.add_development_dependency "timecop"

--- a/montrose.gemspec
+++ b/montrose.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "montrose/version"
 
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "m", "~> 1.5"
   spec.add_development_dependency "minitest", "~> 5.10"
   spec.add_development_dependency "rake", "~> 11.0"
-  spec.add_development_dependency "rubocop", "~> 0.52.1"
+  spec.add_development_dependency "rubocop", "~> 0.64.0"
   spec.add_development_dependency "timecop"
 end

--- a/spec/montrose/examples_spec.rb
+++ b/spec/montrose/examples_spec.rb
@@ -1,0 +1,66 @@
+require "spec_helper"
+
+describe Montrose::Recurrence do
+  describe "examples" do
+    let(:now) { Time.local(2015, 9, 1, 12) } # Tuesday
+
+    before do
+      Timecop.freeze(now)
+    end
+
+    it "every day at 3:30pm" do
+      recurrence = new_recurrence(every: :day, at: "3:30 PM")
+
+      recurrence.events.take(3).must_pair_with [
+        Time.local(2015, 9, 1, 15, 30),
+        Time.local(2015, 9, 2, 15, 30),
+        Time.local(2015, 9, 3, 15, 30)
+      ]
+    end
+
+    it "specifying starts and at option" do
+      recurrence = new_recurrence(every: :week, on: "tuesday", at: "5:00", starts: "2016-06-23")
+
+      recurrence.events.take(3).must_pair_with [
+        Time.local(2016, 6, 28, 5, 0),
+        Time.local(2016, 7, 5,  5, 0),
+        Time.local(2016, 7, 12, 5, 0)
+      ]
+    end
+
+    it "multiple at values" do
+      recurrence = new_recurrence(every: :day, at: ["7:00am", "3:30pm"])
+
+      recurrence.events.take(3).must_pair_with [
+        Time.local(2015, 9, 1, 7,  0),
+        Time.local(2015, 9, 1, 15, 30),
+        Time.local(2015, 9, 2, 7,  0)
+      ]
+    end
+
+    it "anchors to starts time outside of between range" do
+      recurrence = new_recurrence(every: :day,
+                                  interval: 3,
+                                  starts: 1.day.ago,
+                                  between: Date.today..7.days.from_now)
+
+      recurrence.events.to_a.must_pair_with [
+        Time.local(2015, 9, 3, 12),
+        Time.local(2015, 9, 6, 12)
+      ]
+    end
+
+    it "anchors to starts time inside of between range" do
+      recurrence = new_recurrence(every: :day,
+                                  interval: 3,
+                                  starts: 1.day.from_now,
+                                  between: Date.today..7.days.from_now)
+
+      recurrence.events.to_a.must_pair_with [
+        Time.local(2015, 9, 2, 12),
+        Time.local(2015, 9, 5, 12),
+        Time.local(2015, 9, 8, 12)
+      ]
+    end
+  end
+end

--- a/spec/montrose/examples_spec.rb
+++ b/spec/montrose/examples_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Montrose::Recurrence do
@@ -61,6 +63,33 @@ describe Montrose::Recurrence do
         Time.local(2015, 9, 5, 12),
         Time.local(2015, 9, 8, 12)
       ]
+    end
+
+    # https://github.com/rossta/montrose/issues/105
+    describe "yearly in month, nth day of month" do
+      it "when nth day N falls in given month" do
+        recurrence = new_recurrence(every: :year,
+                                    month: 1,
+                                    day: { friday: [2] })
+
+        recurrence.events.take(3).to_a.must_pair_with [
+          Time.local(2016, 1, 8, 12),
+          Time.local(2017, 1, 13, 12),
+          Time.local(2018, 1, 12, 12)
+        ]
+      end
+
+      it "when nth day N falls outside of given month" do
+        recurrence = new_recurrence(every: :year,
+                                    month: 2,
+                                    day: { friday: [2] })
+
+        recurrence.events.take(3).to_a.must_pair_with [
+          Time.local(2016, 2, 12, 12),
+          Time.local(2017, 2, 10, 12),
+          Time.local(2018, 2, 9, 12)
+        ]
+      end
     end
   end
 end

--- a/spec/montrose/recurrence_spec.rb
+++ b/spec/montrose/recurrence_spec.rb
@@ -161,69 +161,6 @@ describe Montrose::Recurrence do
     end
   end
 
-  describe "integration specs" do
-    let(:now) { Time.local(2015, 9, 1, 12) } # Tuesday
-
-    before do
-      Timecop.freeze(now)
-    end
-
-    it "every day at 3:30pm" do
-      recurrence = new_recurrence(every: :day, at: "3:30 PM")
-
-      recurrence.events.take(3).must_pair_with [
-        Time.local(2015, 9, 1, 15, 30),
-        Time.local(2015, 9, 2, 15, 30),
-        Time.local(2015, 9, 3, 15, 30)
-      ]
-    end
-
-    it "specifying starts and at option" do
-      recurrence = new_recurrence(every: :week, on: "tuesday", at: "5:00", starts: "2016-06-23")
-
-      recurrence.events.take(3).must_pair_with [
-        Time.local(2016, 6, 28, 5, 0),
-        Time.local(2016, 7, 5,  5, 0),
-        Time.local(2016, 7, 12, 5, 0)
-      ]
-    end
-
-    it "multiple at values" do
-      recurrence = new_recurrence(every: :day, at: ["7:00am", "3:30pm"])
-
-      recurrence.events.take(3).must_pair_with [
-        Time.local(2015, 9, 1, 7,  0),
-        Time.local(2015, 9, 1, 15, 30),
-        Time.local(2015, 9, 2, 7,  0)
-      ]
-    end
-
-    it "anchors to starts time outside of between range" do
-      recurrence = new_recurrence(every: :day,
-                                  interval: 3,
-                                  starts: 1.day.ago,
-                                  between: Date.today..7.days.from_now)
-
-      recurrence.events.to_a.must_pair_with [
-        Time.local(2015, 9, 3, 12),
-        Time.local(2015, 9, 6, 12)
-      ]
-    end
-
-    it "anchors to starts time inside of between range" do
-      recurrence = new_recurrence(every: :day,
-                                  interval: 3,
-                                  starts: 1.day.from_now,
-                                  between: Date.today..7.days.from_now)
-
-      recurrence.events.to_a.must_pair_with [
-        Time.local(2015, 9, 2, 12),
-        Time.local(2015, 9, 5, 12),
-        Time.local(2015, 9, 8, 12)
-      ]
-    end
-  end
-
   describe "#inspect" do
     let(:now) { time_now }
     let(:recurrence) { new_recurrence(every: :month, starts: now, interval: 1) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ SimpleCov.start do
   add_filter "bundle|gemfiles|spec|vendor"
 end
 
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "montrose"
 
 require "minitest/autorun"
@@ -20,7 +20,7 @@ begin
 rescue LoadError
 end
 
-Dir[File.expand_path("../../spec/support/**/*.rb", __FILE__)].each { |f| require f }
+Dir[File.expand_path("../spec/support/**/*.rb", __dir__)].each { |f| require f }
 
 module Minitest
   class Spec


### PR DESCRIPTION
Fixes #105 

Previously, montrose was interpreting the following options as "2nd friday of year", when it semantically makes more sense to interpret at "2nd friday of month 1"

```ruby
Montrose.yearly(month: 1, day: {friday: [2]} )
```