### PR TITLE
Expand Active Support constraint to allow rails 6

### DIFF
--- a/montrose.gemspec
+++ b/montrose.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "activesupport", ">= 4.1", "< 5.3"
+  spec.add_dependency "activesupport", ">= 4.1", "< 6.0"
 
   spec.add_development_dependency "appraisal", "~> 2.2.0"
   spec.add_development_dependency "m", "~> 1.5"


### PR DESCRIPTION
Rails 6 is currently in [beta2](https://weblog.rubyonrails.org/2019/2/25/Rails-6-0-beta2-released/) and some larger shops are already running it in production; this PR updates the dependency constraints to allow for Rails 6.