### PR TITLE
Ensure :at events recur after start time

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -118,7 +118,7 @@ Style/RegexpLiteral:
   EnforcedStyle: percent_r
 
 Layout/DotPosition:
-  EnforcedStyle: trailing
+  EnforcedStyle: leading
 
 Naming/VariableNumber:
   Enabled: false

--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -229,7 +229,9 @@ module Montrose
       time = starts || default_starts
 
       if at
-        at.map { |(hour, min)| time.change(hour: hour, min: min) }.min || time
+        at.map { |hour, min, sec = 0| time.change(hour: hour, min: min, sec: sec) }
+          .select { |t| t >= time }
+          .min || time
       else
         time
       end

--- a/lib/montrose/rule/after.rb
+++ b/lib/montrose/rule/after.rb
@@ -6,7 +6,7 @@ module Montrose
       include Montrose::Rule
 
       def self.apply_options(opts)
-        opts[:starts] && opts.start_time
+        opts.start_time
       end
 
       # Initializes rule

--- a/spec/montrose/clock_spec.rb
+++ b/spec/montrose/clock_spec.rb
@@ -100,11 +100,13 @@ describe Montrose::Clock do
     end
 
     it "emits increments on at values" do
-      clock = new_clock(every: :day, at: [[10, 0, 59], [15, 30, 34]])
+      Timecop.freeze(Time.local(2018, 5, 31, 11)) do
+        clock = new_clock(every: :day, at: [[10, 0, 59], [15, 30, 34]])
 
-      clock.tick # throwaway default start time
-      clock.tick.must_equal time_now.change(hour: 10, min: 0, sec: 59)
-      clock.tick.must_equal time_now.change(hour: 15, min: 30, sec: 34)
+        clock.tick.must_equal Time.local(2018, 5, 31, 15, 30, 34)
+        clock.tick.must_equal Time.local(2018, 6, 1, 10, 0, 59)
+        clock.tick.must_equal Time.local(2018, 6, 1, 15, 30, 34)
+      end
     end
 
     it "emits correct tick when at values empty" do

--- a/spec/montrose/examples_spec.rb
+++ b/spec/montrose/examples_spec.rb
@@ -34,9 +34,9 @@ describe Montrose::Recurrence do
       recurrence = new_recurrence(every: :day, at: ["7:00am", "3:30pm"])
 
       recurrence.events.take(3).must_pair_with [
-        Time.local(2015, 9, 1, 7,  0),
         Time.local(2015, 9, 1, 15, 30),
-        Time.local(2015, 9, 2, 7,  0)
+        Time.local(2015, 9, 2, 7,  0),
+        Time.local(2015, 9, 2, 15, 30)
       ]
     end
 
@@ -62,6 +62,25 @@ describe Montrose::Recurrence do
         Time.local(2015, 9, 2, 12),
         Time.local(2015, 9, 5, 12),
         Time.local(2015, 9, 8, 12)
+      ]
+    end
+
+    it "returns daily events with :at specified prior to :starts" do
+      starts = 1.day.from_now.beginning_of_day + 12.hours
+      at = "6:00am"
+      recurrence = new_recurrence(every: :day, starts: starts, at: at)
+
+      recurrence.take(3).length.must_equal 3
+    end
+
+    it "returns daily events after current time" do
+      at = "6:00am"
+      recurrence = new_recurrence(every: :day, at: at)
+
+      recurrence.take(3).must_pair_with [
+        Time.local(2015, 9, 2, 6),
+        Time.local(2015, 9, 3, 6),
+        Time.local(2015, 9, 4, 6)
       ]
     end
 

--- a/spec/montrose/options_spec.rb
+++ b/spec/montrose/options_spec.rb
@@ -34,7 +34,7 @@ describe Montrose::Options do
       -> { options[:start_time] = 3.days.from_now }.must_raise
     end
 
-    it "is  :at time on default_starts date" do
+    it "is :at time on default_starts date" do
       noon = Time.local(2015, 9, 1, 12)
       Timecop.freeze(noon)
       options[:at] = "7pm"
@@ -42,18 +42,11 @@ describe Montrose::Options do
       options[:start_time].must_equal Time.local(2015, 9, 1, 19)
     end
 
-    it "is :at time on :starts date" do
-      options[:starts] = Time.local(2016, 6, 23, 12)
-      options[:at] = "10am"
-
-      options[:start_time].must_equal Time.local(2016, 6, 23, 10)
-    end
-
-    it "is earliest of several :at times on default_starts date" do
+    it "is current time despite :at time earlier in day" do
       options[:starts] = Time.local(2019, 12, 25, 20)
       options[:at] = %w[7pm 10am]
 
-      options[:start_time].must_equal Time.local(2019, 12, 25, 10)
+      options[:start_time].must_equal Time.local(2019, 12, 25, 20)
     end
 
     it "is :starts when :at empty" do

--- a/spec/montrose/recurrence_spec.rb
+++ b/spec/montrose/recurrence_spec.rb
@@ -263,13 +263,5 @@ describe Montrose::Recurrence do
         end
       end
     end
-
-    it "returns daily events with :at specified prior to :starts" do
-      starts = 1.day.from_now.beginning_of_day + 12.hours
-      at = "6:00am"
-      recurrence = new_recurrence(every: :day, starts: starts, at: at)
-
-      recurrence.take(3).length.must_equal 3
-    end
   end
 end


### PR DESCRIPTION
Changes the behavior of recurrences with `:at` to ensure instances occur after the given (or implicit) start time.  

For example, if the current time is 12noon local, a recurrence without a `:starts` option and with `:at => %[7am 7pm]` would previously have returned an event for 7am _on today's date_, even though that event is in the past. Though the implicit start time is the current time, the behavior was implemented assuming developers would want all occurrences of the `:at` time on the current date. Citing issues #103, #110 and #117, developers have been confused this behavior.

Now, with the above options, the first event returned will be 7pm, which would be the first event after the implicit start time of 12noon.

To retain the existing behavior, recurrences will need to specify an explicit start time in the past, such as `:starts => Time.now.beginning_of_day`.