### PR TITLE
Bug fix: Define Recurrence#as_json

### DIFF
--- a/lib/montrose/recurrence.rb
+++ b/lib/montrose/recurrence.rb
@@ -318,6 +318,14 @@ module Montrose
       JSON.dump(to_hash, *args)
     end
 
+    # Returns json of options used to create the recurrence
+    #
+    # @return [Hash] json of recurrence options
+    #
+    def as_json
+      to_hash.as_json
+    end
+
     # Returns options used to create the recurrence in YAML format
     #
     # @return [String] YAML-formatted recurrence options

--- a/spec/montrose/recurrence_spec.rb
+++ b/spec/montrose/recurrence_spec.rb
@@ -70,6 +70,20 @@ describe Montrose::Recurrence do
     end
   end
 
+  describe "#as_json" do
+    it "returns default options as json" do
+      options = { every: :day, total: 3, starts: now, interval: 1 }
+      recurrence = new_recurrence(options)
+      hash = recurrence.as_json
+
+      hash.size.must_equal 4
+      hash["every"].must_equal "day"
+      hash["interval"].must_equal 1
+      hash["total"].must_equal 3
+      hash["starts"].must_equal now.as_json
+    end
+  end
+
   describe "#to_yaml" do
     it "returns default options as yaml" do
       options = { every: :day, starts: now, interval: 1, total: 3 }


### PR DESCRIPTION
Fixes #113 
Define Recurrence#as_json

Previously it was impossible to save a non ending recurrence in ActiveRecord: 
```ruby
event = RecurringEvent.new
event.recurrence = Montrose.weekly
event.save # infinite loop
```
Because of:
```ruby
Montrose.weekly.as_json # infinite loop
```

After this commit everything is fixed :)