### PR TITLE
Schedule serialization

### DIFF
--- a/lib/montrose/schedule.rb
+++ b/lib/montrose/schedule.rb
@@ -10,24 +10,24 @@ module Montrose
   class Schedule
     attr_accessor :rules
 
-    # Instantiates a schedule and yields the instance to an optional
-    # block for building recurrences inline
-    #
-    # @example Build a schedule with multiple rules added in the given block
-    #   schedule = Montrose::Schedule.build do |s|
-    #     s << { every: :day }
-    #     s << { every: :year }
-    #   end
-    #
-    # @return [Montrose::Schedule]
-    #
-    def self.build
-      schedule = new
-      yield schedule if block_given?
-      schedule
-    end
-
     class << self
+      # Instantiates a schedule and yields the instance to an optional
+      # block for building recurrences inline
+      #
+      # @example Build a schedule with multiple rules added in the given block
+      #   schedule = Montrose::Schedule.build do |s|
+      #     s << { every: :day }
+      #     s << { every: :year }
+      #   end
+      #
+      # @return [Montrose::Schedule]
+      #
+      def build
+        schedule = new
+        yield schedule if block_given?
+        schedule
+      end
+
       def dump(obj)
         return nil if obj.nil?
         return dump(load(obj)) if obj.is_a?(String)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,10 +24,8 @@ Dir[File.expand_path("../spec/support/**/*.rb", __dir__)].each { |f| require f }
 
 module Minitest
   class Spec
-    def new_schedule(options = {})
-      schedule = Montrose::Schedule.new
-      schedule << options if options.any?
-      schedule
+    def new_schedule(rules = [])
+      Montrose::Schedule.new(rules)
     end
 
     def new_recurrence(options = {})


### PR DESCRIPTION
Implements `Schedule.dump` and `Schedule.load` to support serialization, as for ActiveRecord.