### PR TITLE
Make schedule enumerable and serializable

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,40 @@ r.events.take(10).each { |date| puts date.to_s }
 r.events.lazy.select { |time| time > 1.month.from_now }.take(3).each { |date| puts date.to_s }
 ```
 
+### Combining recurrences
+
+It may be necessary to combine several recurrence rules into a single
+enumeration of events. For this purpose, there is `Montrose::Schedule`. To create a schedule of multiple recurrences:
+
+```ruby
+recurrence_1 = Montrose.monthly(day: { friday: [1] })
+recurrence_2 = Montrose.weekly(on: :tuesday)
+
+schedule = Montrose::Schedule.build do |s|
+  s << recurrence_1
+  s << recurrence_2
+end
+
+# add after building
+s << Montrose.yearly
+```
+The `Schedule#<<` method also accepts valid recurrence options as hashes:
+```ruby
+schedule = Montrose::Schedule.build do |s|
+  s << { day: { friday: [1] } }
+  s << { on: :tuesday }
+end
+```
+A schedule acts like a collection of recurrence rules that also behaves as a single
+stream of events:
+
+```ruby
+schedule.events # => #<Enumerator: ...>
+schedule.each do |event|
+  puts event
+end
+```
+
 ### Ruby on Rails
 
 Instances of `Montrose::Recurrence` support the ActiveRecord serialization API so recurrence objects can be marshalled to and from a single database column:
@@ -373,6 +407,13 @@ Instances of `Montrose::Recurrence` support the ActiveRecord serialization API s
 ```ruby
 class RecurringEvent < ApplicationRecord
   serialize :recurrence, Montrose::Recurrence
+
+end
+```
+`Montrose::Schedule` can also be serialized:
+```ruby
+class RecurringEvent < ApplicationRecord
+  serialize :recurrence, Montrose::Schedule
 
 end
 ```

--- a/lib/montrose/schedule.rb
+++ b/lib/montrose/schedule.rb
@@ -133,8 +133,40 @@ module Montrose
       end
     end
 
+    # Returns an array of the options used to create the recurrence
+    #
+    # @return [Array] array of hashes of recurrence options
+    #
     def to_a
       @rules.map(&:to_hash)
+    end
+
+    # Returns json string of options used to create the schedule
+    #
+    # @return [String] json of schedule recurrences
+    #
+    def to_json(*args)
+      JSON.dump(to_a, *args)
+    end
+
+    # Returns json array of options used to create the schedule
+    #
+    # @return [Array] json of schedule recurrence options
+    #
+    def as_json(*args)
+      to_a.as_json(*args)
+    end
+
+    # Returns options used to create the schedule recurrences in YAML format
+    #
+    # @return [String] YAML-formatted schedule recurrence options
+    #
+    def to_yaml(*args)
+      YAML.dump(JSON.parse(to_json(*args)))
+    end
+
+    def inspect
+      "#<#{self.class}:#{object_id.to_s(16)} #{to_a.inspect}>"
     end
 
     private

--- a/lib/montrose/schedule.rb
+++ b/lib/montrose/schedule.rb
@@ -8,6 +8,8 @@ module Montrose
   # @attr_reader [Array] rules the list of recurrences
   #
   class Schedule
+    include Enumerable
+
     attr_accessor :rules
 
     class << self
@@ -84,6 +86,31 @@ module Montrose
     #
     def include?(timestamp)
       @rules.any? { |r| r.include?(timestamp) }
+    end
+
+    # Iterate over the events of a recurrence. Along with the Enumerable
+    # module, this makes Montrose occurrences enumerable like other Ruby
+    # collections
+    #
+    # @example Iterate over a finite recurrence
+    #   schedule = Montrose::Schedule.build do |s|
+    #     s << { every: :day }
+    #   end
+    #   schedule.each do |event|
+    #     puts event
+    #   end
+    #
+    # @example Iterate over an infinite recurrence
+    #   schedule = Montrose::Schedule.build do |s|
+    #     s << { every: :day }
+    #   end
+    #   schedule.lazy.each do |event|
+    #     puts event
+    #   end
+    #
+    # @return [Enumerator] an enumerator of recurrence timestamps
+    def each(&block)
+      events.each(&block)
     end
 
     # Returns an enumerator for iterating over timestamps in the schedule

--- a/spec/montrose/schedule_spec.rb
+++ b/spec/montrose/schedule_spec.rb
@@ -20,58 +20,6 @@ describe Montrose::Schedule do
     end
   end
 
-  describe "#add" do
-    it "adds options as new recurrence rule" do
-      options = { every: :year, total: 3 }
-      schedule.add(options)
-
-      schedule.rules.size.must_equal 1
-
-      rule = schedule.rules.first
-      rule.default_options[:every].must_equal :year
-      rule.default_options[:total].must_equal 3
-    end
-
-    it "accepts a recurrence rule" do
-      schedule.add(Montrose.yearly.total(3))
-
-      schedule.rules.size.must_equal 1
-
-      rule = schedule.rules.first
-      rule.default_options[:every].must_equal :year
-      rule.default_options[:total].must_equal 3
-    end
-
-    it "is aliased to #<<" do
-      options = { every: :year, total: 3 }
-      schedule << options
-
-      schedule.rules.size.must_equal 1
-
-      rule = schedule.rules.first
-      rule.default_options[:every].must_equal :year
-      rule.default_options[:total].must_equal 3
-    end
-  end
-
-  describe "#events" do
-    it "combines events of given rules in order" do
-      today = Date.today.to_time
-
-      schedule.add(every: 2.days, total: 2, starts: today)
-      schedule.add(every: 2.days, total: 2, starts: today + 1.day)
-
-      events = schedule.events.to_a
-      events.must_pair_with [
-        today,
-        today + 1.day,
-        today + 2.days,
-        today + 3.days
-      ]
-      events.size.must_equal 4
-    end
-  end
-
   describe ".dump" do
     it "returns options as JSON string" do
       schedule = new_schedule([
@@ -160,6 +108,84 @@ describe Montrose::Schedule do
       loaded = Montrose::Schedule.load("")
 
       loaded.must_be_nil
+    end
+  end
+
+  describe "#add" do
+    it "adds options as new recurrence rule" do
+      options = { every: :year, total: 3 }
+      schedule.add(options)
+
+      schedule.rules.size.must_equal 1
+
+      rule = schedule.rules.first
+      rule.default_options[:every].must_equal :year
+      rule.default_options[:total].must_equal 3
+    end
+
+    it "accepts a recurrence rule" do
+      schedule.add(Montrose.yearly.total(3))
+
+      schedule.rules.size.must_equal 1
+
+      rule = schedule.rules.first
+      rule.default_options[:every].must_equal :year
+      rule.default_options[:total].must_equal 3
+    end
+
+    it "is aliased to #<<" do
+      options = { every: :year, total: 3 }
+      schedule << options
+
+      schedule.rules.size.must_equal 1
+
+      rule = schedule.rules.first
+      rule.default_options[:every].must_equal :year
+      rule.default_options[:total].must_equal 3
+    end
+  end
+
+  describe "#events" do
+    it "combines events of given rules in order" do
+      today = Date.today.to_time
+
+      schedule.add(every: 2.days, total: 2, starts: today)
+      schedule.add(every: 2.days, total: 2, starts: today + 1.day)
+
+      events = schedule.events.to_a
+      events.must_pair_with [
+        today,
+        today + 1.day,
+        today + 2.days,
+        today + 3.days
+      ]
+      events.size.must_equal 4
+    end
+
+    it "is an enumerator" do
+      schedule.events.must_be_instance_of(Enumerator)
+    end
+  end
+
+  describe "#each" do
+    it "is defined" do
+      schedule.must_respond_to :each
+    end
+
+    it "responsds to enumerable methods" do
+      today = Date.today.to_time
+
+      schedule.add(every: 2.days, total: 2, starts: today)
+      schedule.add(every: 2.days, total: 2, starts: today + 1.day)
+
+      events = schedule.take(4).to_a
+      events.must_pair_with [
+        today,
+        today + 1.day,
+        today + 2.days,
+        today + 3.days
+      ]
+      events.size.must_equal 4
     end
   end
 

--- a/spec/montrose/schedule_spec.rb
+++ b/spec/montrose/schedule_spec.rb
@@ -269,4 +269,71 @@ describe Montrose::Schedule do
         "Elased time was too long: %.1f seconds" % elapsed
     end
   end
+
+  describe "#inspect" do
+    before do
+      schedule << { every: :month }
+      schedule << { every: :day }
+    end
+
+    it "is readable" do
+      inspected = "#<Montrose::Schedule:#{schedule.object_id.to_s(16)} " \
+                  "[{:every=>:month}, {:every=>:day}]>"
+      schedule.inspect.must_equal inspected
+    end
+  end
+
+  describe "#to_json" do
+    before do
+      schedule << { every: :month }
+      schedule << { every: :day }
+    end
+
+    it "returns json string of its options" do
+      schedule.to_json.must_equal "[{\"every\":\"month\"},{\"every\":\"day\"}]"
+    end
+  end
+
+  describe "#to_a" do
+    before do
+      schedule << { every: :month }
+      schedule << { every: :day }
+    end
+
+    it "returns default options as array" do
+      array = schedule.to_a
+
+      array.size.must_equal 2
+      array.must_equal [{ every: :month }, { every: :day }]
+    end
+  end
+
+  describe "#as_json" do
+    before do
+      schedule << { every: :month }
+      schedule << { every: :day }
+    end
+
+    it "returns default options as array" do
+      array = schedule.as_json
+
+      array.size.must_equal 2
+      array.must_equal [{ "every" => "month" }, { "every" => "day" }]
+    end
+  end
+
+  describe "#to_yaml" do
+    before do
+      schedule << { every: :month }
+      schedule << { every: :day }
+    end
+
+    it "returns default options as array" do
+      yaml = schedule.to_yaml
+
+      array = YAML.safe_load(yaml)
+      array.size.must_equal 2
+      array.must_equal [{ "every" => "month" }, { "every" => "day" }]
+    end
+  end
 end


### PR DESCRIPTION
Adds:
* `Schedule#each`
* `Schedule#to_json`
* `Schedule#as_json`
* `Schedule#to_yaml`
* README updates