### PR TITLE
Allow compatibility with Rails 6.0.1+ 

### DIFF
--- a/montrose.gemspec
+++ b/montrose.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "activesupport", ">= 4.1", "<= 6.0"
+  spec.add_dependency "activesupport", ">= 4.1", "<= 7.0"
 
   spec.add_development_dependency "appraisal", "~> 2.2.0"
   spec.add_development_dependency "m", "~> 1.5"


### PR DESCRIPTION
Current version of `montrose` only allows it to be used with Rails `<= 6.0`, which won't work for Rails `6.0.1` (released 2019-11-05).

This PR updates the gemspec dependency to allow `montrose` to work with any Rails `>= 4.1` and `<= 7.0`, with the result that it can now be used with any Rails `6+` application.

I tested on one of my prodution apps where I modified my Gemfile from `rails 6.0` to `rails 6.0.1` and it would break when running `bundle update rails`.

Issue was resolved when I forked `montrose` and updated the dependency to allow `rails <= 7.0`.

If `montrose` is going to resolve this in one of its planned releases, please disregard this PR and I'll use my forked version until the official version is ready.

Thanks for the work on `montrose`, it's an awesome gem and I appreciate your work on it!