### PR TITLE
Ensure finite? returns a boolean; add infinite? method

### DIFF
--- a/lib/montrose/recurrence.rb
+++ b/lib/montrose/recurrence.rb
@@ -354,12 +354,20 @@ module Montrose
       end or false
     end
 
-    # Return true/false if recurrence will iterate infinitely
+    # Return true/false if recurrence will terminate
     #
-    # @return [Boolean] whether or not recurrence is infinite
+    # @return [Boolean] returns true if recurrence has an end
     #
     def finite?
-      ends_at || length
+      !infinite?
+    end
+
+    # Return true/false if recurrence will iterate infinitely
+    #
+    # @return [Boolean] returns true if recurrence has no end
+    #
+    def infinite?
+      !ends_at && !length
     end
 
     # Return true/false if given timestamp occurs before

--- a/spec/montrose/recurrence_spec.rb
+++ b/spec/montrose/recurrence_spec.rb
@@ -256,6 +256,26 @@ describe Montrose::Recurrence do
     end
   end
 
+  describe "#finite? / #infinite?" do
+    it "is true if there is an ends at" do
+      recurrence = new_recurrence(every: :day).ending(1.day.from_now)
+      assert_equal recurrence.finite?, true
+      assert_equal recurrence.infinite?, false
+    end
+
+    it "is true if there is a length" do
+      recurrence = new_recurrence(every: :day).repeat(3)
+      assert_equal recurrence.finite?, true
+      assert_equal recurrence.infinite?, false
+    end
+
+    it "is false if there is no end date or length" do
+      recurrence = new_recurrence(every: :day)
+      assert_equal recurrence.finite?, false
+      assert_equal recurrence.infinite?, true
+    end
+  end
+
   describe "intervals" do
     before do
       Timecop.return # turn off timecop to test enumeration against real clock


### PR DESCRIPTION
After using montrose on a project I noticed that the `finite?` method was returning the end date instead of a boolean. While I was at it I added the `infinite?` shortcut to make the code a bit nicer.

Let me know if there's anything you would like me to clean up/change.

Thanks :)