### PR TITLE
added failing include? specs for weekly recurrences with intervals

### DIFF
--- a/spec/montrose/examples_spec.rb
+++ b/spec/montrose/examples_spec.rb
@@ -30,6 +30,14 @@ describe Montrose::Recurrence do
       ]
     end
 
+    it "every 2 weeks" do
+      start_date = Date.new(2019, 12, 2)
+      recurrence = new_recurrence(every: :week, interval: 2, starts: start_date)
+
+      assert recurrence.include?(start_date.to_time + 2.weeks)
+      refute recurrence.include?(start_date.to_time + 1.weeks)
+    end
+
     it "multiple at values" do
       recurrence = new_recurrence(every: :day, at: ["7:00am", "3:30pm"])
 

--- a/spec/montrose/frequency/weekly_spec.rb
+++ b/spec/montrose/frequency/weekly_spec.rb
@@ -32,6 +32,30 @@ describe Montrose::Frequency::Weekly do
       refute frequency.include? now + 1.weeks
       refute frequency.include? now + 3.weeks
     end
+
+    it "is true when matches given weekly interval with specific days" do
+      start_date = Date.new(2020, 12, 2)
+      frequency = new_frequency(every: :week, interval: 2, on: [:wednesday], starts: start_date)
+
+      assert frequency.include? start_date.to_time + 2.weeks
+      assert frequency.include? start_date.to_time + 4.weeks
+    end
+
+    it "is false when matches given weekly interval but not specific day" do
+      start_date = Date.new(2020, 12, 2)
+      frequency = new_frequency(every: :week, interval: 2, on: [:wednesday], starts: start_date)
+
+      refute frequency.include? start_date.to_time + 2.weeks + 1.day
+      refute frequency.include? start_date.to_time + 4.weeks + 1.day
+    end
+
+    it "is false when does not match given weekly interval with specific days" do
+      start_date = Date.new(2020, 12, 2)
+      frequency = new_frequency(every: :week, interval: 2, on: [:wednesday], starts: start_date)
+
+      refute frequency.include? start_date.to_time + 1.weeks
+      refute frequency.include? start_date.to_time + 9.weeks
+    end
   end
 
   describe "#to_cron" do


### PR DESCRIPTION
Hi @rossta ! First of all, thanks for the lib, we use it extensively in our product 👍 I'm continuing @mmagn work whom already asked you a few questions here.

In this PR, I've only added 2 failing specs, and I'd be willing to try and fix them if you confirm that they are problematic (and not that I misunderstood how to use montrose).

Both relate to calling `include?` on weekly reccurences with intervals != 1. 

1. The first failing spec I added is at the `frequency` level : if I set a specific weekday like `on: [:wednesday]` it seems to be ignored by the `include?` call (in total I added 3 spec cases in the weekly frequency spec file, but only one fails, the one with the `wednesday` day)

2. The second is the one that I care most about. I test at the `Recurrence` level with `every: :week, interval: 2` options. The interval seems to be ignored in the `include?` calls.

Thank you