### PR TITLE
Fix weekly interval include

### DIFF
--- a/lib/montrose.rb
+++ b/lib/montrose.rb
@@ -45,14 +45,14 @@ module Montrose
     attr_reader :enable_deprecated_between_masking
 
     def enable_deprecated_between_masking=(value)
-      warn '[DEPRECATION] Montrose.enable_deprecated_between_masking is deprecated and will be removed in a future version.'
+      warn "[DEPRECATION] Montrose.enable_deprecated_between_masking is deprecated and will be removed in a future version."
       @enable_deprecated_between_masking = value
     end
 
     def enable_deprecated_between_masking?
       result = !!enable_deprecated_between_masking
       if result
-        warn '[DEPRECATION] Legacy Montrose.between masking behavior is deprecated. Please use Montrose.covering instead to retain this behavior.'
+        warn "[DEPRECATION] Legacy Montrose.between masking behavior is deprecated. Please use Montrose.covering instead to retain this behavior."
       end
       result
     end

--- a/lib/montrose/recurrence.rb
+++ b/lib/montrose/recurrence.rb
@@ -346,12 +346,25 @@ module Montrose
     def include?(timestamp)
       return false if earlier?(timestamp) || later?(timestamp)
 
-      recurrence = finite? ? self : starts(timestamp)
+      recurrence = finite? ? self : fast_forward(timestamp)
 
       recurrence.events.lazy.each do |event|
         return true if event == timestamp
         return false if event > timestamp
       end || false
+    end
+
+    def fast_forward(timestamp)
+      return starts(timestamp) unless starts_at.present?
+
+      interval = default_options[:interval]
+      frequency = default_options[:every]
+      duration = interval.send(frequency)
+
+      # Calculate nearest earlier time ahead matching frequency * interval
+      jump = ((timestamp - starts_at) / duration).floor * duration
+
+      starts(starts_at + jump)
     end
 
     # Return true/false if recurrence will terminate

--- a/spec/montrose/examples_spec.rb
+++ b/spec/montrose/examples_spec.rb
@@ -30,6 +30,14 @@ describe Montrose::Recurrence do
       ]
     end
 
+    it "every 2 weeks" do
+      start_date = Date.new(2019, 12, 2)
+      recurrence = new_recurrence(every: :week, interval: 2, starts: start_date)
+
+      assert recurrence.include?(start_date.to_time + 2.weeks)
+      refute recurrence.include?(start_date.to_time + 1.weeks)
+    end
+
     it "multiple at values" do
       recurrence = new_recurrence(every: :day, at: ["7:00am", "3:30pm"])
 

--- a/spec/montrose/examples_spec.rb
+++ b/spec/montrose/examples_spec.rb
@@ -56,7 +56,7 @@ describe Montrose::Recurrence do
 
       recurrence.events.to_a.must_pair_with [
         Time.local(2015, 8, 31, 12),
-        Time.local(2015, 9, 3,  12)
+        Time.local(2015, 9, 3, 12)
       ]
     end
 

--- a/spec/montrose/frequency/weekly_spec.rb
+++ b/spec/montrose/frequency/weekly_spec.rb
@@ -32,6 +32,30 @@ describe Montrose::Frequency::Weekly do
       refute frequency.include? now + 1.weeks
       refute frequency.include? now + 3.weeks
     end
+
+    it "is true when matches given weekly interval with specific days" do
+      start_date = Date.new(2020, 12, 2)
+      frequency = new_frequency(every: :week, interval: 2, on: [:wednesday], starts: start_date)
+
+      assert frequency.include? start_date.to_time + 2.weeks
+      assert frequency.include? start_date.to_time + 4.weeks
+    end
+
+    it "is false when matches given weekly interval but not specific day" do
+      start_date = Date.new(2020, 12, 2)
+      frequency = new_frequency(every: :week, interval: 2, on: [:wednesday], starts: start_date)
+
+      refute frequency.include? start_date.to_time + 2.weeks + 1.day
+      refute frequency.include? start_date.to_time + 4.weeks + 1.day
+    end
+
+    it "is false when does not match given weekly interval with specific days" do
+      start_date = Date.new(2020, 12, 2)
+      frequency = new_frequency(every: :week, interval: 2, on: [:wednesday], starts: start_date)
+
+      refute frequency.include? start_date.to_time + 1.weeks
+      refute frequency.include? start_date.to_time + 9.weeks
+    end
   end
 
   describe "#to_cron" do

--- a/spec/montrose/frequency/weekly_spec.rb
+++ b/spec/montrose/frequency/weekly_spec.rb
@@ -32,30 +32,6 @@ describe Montrose::Frequency::Weekly do
       refute frequency.include? now + 1.weeks
       refute frequency.include? now + 3.weeks
     end
-
-    it "is true when matches given weekly interval with specific days" do
-      start_date = Date.new(2020, 12, 2)
-      frequency = new_frequency(every: :week, interval: 2, on: [:wednesday], starts: start_date)
-
-      assert frequency.include? start_date.to_time + 2.weeks
-      assert frequency.include? start_date.to_time + 4.weeks
-    end
-
-    it "is false when matches given weekly interval but not specific day" do
-      start_date = Date.new(2020, 12, 2)
-      frequency = new_frequency(every: :week, interval: 2, on: [:wednesday], starts: start_date)
-
-      refute frequency.include? start_date.to_time + 2.weeks + 1.day
-      refute frequency.include? start_date.to_time + 4.weeks + 1.day
-    end
-
-    it "is false when does not match given weekly interval with specific days" do
-      start_date = Date.new(2020, 12, 2)
-      frequency = new_frequency(every: :week, interval: 2, on: [:wednesday], starts: start_date)
-
-      refute frequency.include? start_date.to_time + 1.weeks
-      refute frequency.include? start_date.to_time + 9.weeks
-    end
   end
 
   describe "#to_cron" do

--- a/spec/montrose/rule/covering_spec.rb
+++ b/spec/montrose/rule/covering_spec.rb
@@ -6,7 +6,7 @@ describe Montrose::Rule::Covering do
   let(:now) { Time.new(2015, 9, 3, 12, 0, 0, "-04:00") }
 
   let(:starts) { now - 1.days }
-  let(:ends)   { now + 3.days }
+  let(:ends) { now + 3.days }
 
   describe "time range" do
     let(:rule) { Montrose::Rule::Covering.new(starts..ends) }
@@ -36,8 +36,8 @@ describe Montrose::Rule::Covering do
       it { refute rule.include?(Time.new(2015, 9, 1, 21, 0, 0, "-04:00")) }
 
       it { refute rule.include?(Time.new(2015, 9, 1, 23, 0, 0, "-04:00")) }
-      it { assert rule.include?(Time.new(2015, 9, 2, 00, 0, 0, "-04:00")) }
-      it { assert rule.include?(Time.new(2015, 9, 2, 01, 0, 0, "-04:00")) }
+      it { assert rule.include?(Time.new(2015, 9, 2, 0, 0, 0, "-04:00")) }
+      it { assert rule.include?(Time.new(2015, 9, 2, 1, 0, 0, "-04:00")) }
 
       it { assert rule.include?(now - 1.days) }
 
@@ -49,8 +49,8 @@ describe Montrose::Rule::Covering do
       it { assert rule.include?(Time.new(2015, 9, 6, 21, 0, 0, "-04:00")) }
 
       it { assert rule.include?(Time.new(2015, 9, 6, 23, 0, 0, "-04:00")) }
-      it { refute rule.include?(Time.new(2015, 9, 7, 00, 0, 0, "-04:00")) }
-      it { refute rule.include?(Time.new(2015, 9, 7, 01, 0, 0, "-04:00")) }
+      it { refute rule.include?(Time.new(2015, 9, 7, 0, 0, 0, "-04:00")) }
+      it { refute rule.include?(Time.new(2015, 9, 7, 1, 0, 0, "-04:00")) }
 
       it { refute rule.include?(now + 10.days) }
     end


### PR DESCRIPTION
When using an interval, an infinite recurrence can return incorrect results for `#include?`.

The `#include?` method optimization for infinite recurrences is adjusted to take the given interval into account.

Fixes #132 