### PR TITLE
Make During rule work for time range spanning midnight

### DIFF
--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -226,7 +226,7 @@ module Montrose
     end
 
     def at=(time)
-      @at = map_arg(time) { |t| as_time_parts(t) }
+      @at = map_arg(time) { |t| time_of_day_parse(t).parts }
     end
 
     def on=(arg)
@@ -343,13 +343,6 @@ module Montrose
       item
     end
 
-    def as_time_parts(arg)
-      return arg if arg.is_a?(Array)
-
-      time = as_time(arg)
-      [time.hour, time.min, time.sec]
-    end
-
     def parse_frequency(input)
       if input.respond_to?(:parts)
         frequency, interval = duration_to_frequency_parts(input)
@@ -379,18 +372,18 @@ module Montrose
     def decompose_during_arg(during_arg)
       case during_arg
       when Range
-        [decompose_during_part(during_arg)]
+        [decompose_during_parts(during_arg)]
       else
-        map_arg(during_arg) { |d| decompose_during_part(d) } || []
+        map_arg(during_arg) { |d| decompose_during_parts(d) } || []
       end
     end
 
-    def decompose_during_part(during_parts)
+    def decompose_during_parts(during_parts)
       case during_parts
       when Range
-        decompose_during_part([during_parts.first, during_parts.last])
+        decompose_during_parts([during_parts.first, during_parts.last])
       when String
-        decompose_during_part(during_parts.split(/[-—–]/))
+        decompose_during_parts(during_parts.split(/[-—–]/))
       else
         during_parts.map { |parts| time_of_day_parse(parts) }
       end

--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "montrose/time_of_day"
+
 module Montrose
   class Options
     include Montrose::Utils
@@ -391,16 +393,19 @@ module Montrose
       end
     end
 
-    def time_of_day(time_parts)
-      TimeOfDay.new(time_parts)
+    def decompose_during_part(during_part)
+      case during_part
+      when Range
+        [as_time_parts(during_part.first), as_time_parts(during_part.last)]
+      when String
+        during_part.split(/[-—–]/).map { |d| as_time_parts(d) }
+      else
+        as_time_parts(during_part)
+      end
     end
 
-    class TimeOfDay < SimpleDelegator
-      include Comparable
-
-      def <=>(other)
-        __getobj__ <=> other
-      end
+    def time_of_day(time_parts)
+      ::Montrose::TimeOfDay.new(time_parts)
     end
   end
 end

--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -196,15 +196,18 @@ module Montrose
 
     def during=(during_arg)
       normalized_args = decompose_during_arg(during_arg) or return
+      normalized_args = normalized_args.map { |first, last|
+        [time_of_day(first), time_of_day(last)]
+      }
 
-      @during = normalized_args.each_with_object([]) { |during_parts, all|
-        if time_of_day(during_parts.last) < time_of_day(during_parts.first)
+      @during = normalized_args.each_with_object([]) { |(start_tod, end_tod), all|
+        if end_tod < start_tod
           all.push(
-            [during_parts.first, end_of_day.parts],
-            [beginning_of_day.parts, during_parts.last]
+            [start_tod.parts, end_of_day.parts],
+            [beginning_of_day.parts, end_tod.parts]
           )
         else
-          all.push(during_parts)
+          all.push([start_tod.parts, end_tod.parts])
         end
       }
     end

--- a/lib/montrose/rule/during.rb
+++ b/lib/montrose/rule/during.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "montrose/time_of_day"
+
 module Montrose
   module Rule
     class During
@@ -21,22 +23,10 @@ module Montrose
         @during.any? { |range| range.include?(time) }
       end
 
-      class TimeOfDay
-        def initialize(hour, min, sec)
-          @hour = hour
-          @min = min
-          @sec = sec
-        end
-
-        def seconds_since_midnight
-          @seconds_since_midnight ||= (@hour * 60 * 60) + (@min * 60) + @sec
-        end
-      end
-
       class TimeOfDayRange
         def initialize(first, last, exclude_end: false)
-          @first = TimeOfDay.new(*first)
-          @last = TimeOfDay.new(*last)
+          @first = ::Montrose::TimeOfDay.new(first)
+          @last = ::Montrose::TimeOfDay.new(last)
           @exclude_end = exclude_end
         end
 

--- a/lib/montrose/rule/during.rb
+++ b/lib/montrose/rule/during.rb
@@ -40,7 +40,8 @@ module Montrose
           @range ||= Range.new(
             @first.seconds_since_midnight,
             @last.seconds_since_midnight,
-            @exclude_end)
+            @exclude_end
+          )
         end
       end
     end

--- a/lib/montrose/rule/during.rb
+++ b/lib/montrose/rule/during.rb
@@ -47,7 +47,10 @@ module Montrose
         private
 
         def range
-          @range ||= Range.new(@first.seconds_since_midnight, @last.seconds_since_midnight, @exclude_end)
+          @range ||= Range.new(
+            @first.seconds_since_midnight,
+            @last.seconds_since_midnight,
+            @exclude_end)
         end
       end
     end

--- a/lib/montrose/rule/time_of_day.rb
+++ b/lib/montrose/rule/time_of_day.rb
@@ -24,7 +24,7 @@ module Montrose
       private
 
       def parts(time)
-        [time.hour, time.min, time.sec]
+        ::Montrose::TimeOfDay.to_parts(time)
       end
     end
   end

--- a/lib/montrose/time_of_day.rb
+++ b/lib/montrose/time_of_day.rb
@@ -11,7 +11,11 @@ module Montrose
     end
 
     def self.from_time(time)
-      new([time.hour, time.min, time.sec])
+      new(to_parts(time))
+    end
+
+    def self.to_parts(time)
+      [time.hour, time.min, time.sec]
     end
 
     def initialize(parts)

--- a/lib/montrose/time_of_day.rb
+++ b/lib/montrose/time_of_day.rb
@@ -2,6 +2,12 @@ module Montrose
   class TimeOfDay
     include Comparable
 
+    attr_reader :parts, :hour, :min, :sec
+
+    def self.from_time(time)
+      new([time.hour, time.min, time.sec])
+    end
+
     def initialize(parts)
       @parts = parts
       @hour, @min, @sec = *parts

--- a/lib/montrose/time_of_day.rb
+++ b/lib/montrose/time_of_day.rb
@@ -1,0 +1,22 @@
+module Montrose
+  class TimeOfDay
+    include Comparable
+
+    def initialize(parts)
+      @parts = parts
+      @hour, @min, @sec = *parts
+    end
+
+    def seconds_since_midnight
+      @seconds_since_midnight ||= (@hour * 60 * 60) + (@min * 60) + @sec
+    end
+
+    def to_a
+      @parts
+    end
+
+    def <=>(other)
+      to_a <=> other.to_a
+    end
+  end
+end

--- a/lib/montrose/time_of_day.rb
+++ b/lib/montrose/time_of_day.rb
@@ -4,6 +4,12 @@ module Montrose
 
     attr_reader :parts, :hour, :min, :sec
 
+    def self.parse(arg)
+      return new(arg) if arg.is_a?(Array)
+
+      from_time(::Montrose::Utils.as_time(arg))
+    end
+
     def self.from_time(time)
       new([time.hour, time.min, time.sec])
     end
@@ -21,8 +27,18 @@ module Montrose
       @parts
     end
 
+    # def inspect
+    #   "#<Montrose::TimeOfDay #{format_time(@hour)}:#{format_time(@min)}:#{format_time(@sec)}"
+    # end
+
     def <=>(other)
       to_a <=> other.to_a
+    end
+
+    private
+
+    def format_time(part)
+      format('%02d', part)
     end
   end
 end

--- a/lib/montrose/time_of_day.rb
+++ b/lib/montrose/time_of_day.rb
@@ -38,7 +38,7 @@ module Montrose
     private
 
     def format_time(part)
-      format('%02d', part)
+      format("%02d", part)
     end
   end
 end

--- a/spec/montrose/options_spec.rb
+++ b/spec/montrose/options_spec.rb
@@ -696,6 +696,13 @@ describe Montrose::Options do
       options[:during].must_equal [[[9, 0, 0], [17, 0, 0]], [[19, 30, 0], [23, 30, 0]]]
     end
 
+    it "splits args parts before and after midnight when spanning overnight" do
+      options[:during] = "5pm - 9am"
+
+      options.during.must_equal [[[17, 0, 0], [23, 59, 59]], [[0, 0, 0], [9, 0, 0]]]
+      options[:during].must_equal [[[17, 0, 0], [23, 59, 59]], [[0, 0, 0], [9, 0, 0]]]
+    end
+
     it "can be set to nil" do
       options[:during] = nil
 

--- a/spec/montrose/rule/during_spec.rb
+++ b/spec/montrose/rule/during_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Montrose::Rule::During do
+  def time_of_day(*time_of_day_parts)
+    Time.new(2015, 9, 3, *time_of_day_parts, "-04:00")
+  end
+
+  describe "single tuple" do
+    let(:rule) { Montrose::Rule::During.new([[[9, 0, 0], [17, 0, 0]]]) }
+
+    describe "#include?" do
+      it { refute rule.include?(time_of_day(0, 0, 0)) }
+      it { refute rule.include?(time_of_day(8, 59, 0)) }
+      it { assert rule.include?(time_of_day(9, 0, 0)) }
+      it { assert rule.include?(time_of_day(12, 0, 0)) }
+      it { assert rule.include?(time_of_day(17, 0, 0)) }
+      it { refute rule.include?(time_of_day(17, 1, 0)) }
+      it { refute rule.include?(time_of_day(23, 59, 0)) }
+    end
+  end
+
+  describe "multiple tuples" do
+    let(:rule) {
+      Montrose::Rule::During.new([
+        [[9, 0, 0], [11, 0, 0]],
+        [[12, 0, 0], [14, 0, 0]]
+      ])
+    }
+
+    describe "#include?" do
+      it { refute rule.include?(time_of_day(0, 0, 0)) }
+      it { refute rule.include?(time_of_day(8, 59, 0)) }
+      it { assert rule.include?(time_of_day(9, 0, 0)) }
+      it { assert rule.include?(time_of_day(10, 0, 0)) }
+      it { assert rule.include?(time_of_day(11, 0, 0)) }
+      it { refute rule.include?(time_of_day(11, 30, 0)) }
+      it { assert rule.include?(time_of_day(12, 0, 0)) }
+      it { assert rule.include?(time_of_day(13, 0, 0)) }
+      it { assert rule.include?(time_of_day(14, 0, 0)) }
+      it { refute rule.include?(time_of_day(17, 0, 0)) }
+      it { refute rule.include?(time_of_day(17, 1, 0)) }
+      it { refute rule.include?(time_of_day(23, 59, 0)) }
+    end
+  end
+end


### PR DESCRIPTION
Previously, a recurrence with a during rule that spans overnight would not return expected results. 

Now:
```ruby
r = Montrose.hourly.during('11pm-3am').starts(Time.now).until(Time.now + 1.day)
=> #<Montrose::Recurrence:708 {:every=>:hour, :starts=>2021-02-03 21:21:01 -0500, :until=>2021-02-04 21:21:01 -0500, :during=>[[[23, 0, 0], [23, 59, 59]], [[0, 0, 0], [3, 0, 0]]]}>
r.events.to_a
=> [
 2021-02-03 23:21:01 -0500, 
 2021-02-04 00:21:01 -0500, 
 2021-02-04 01:21:01 -0500, 
 2021-02-04 02:21:01 -0500
]
```
Fixes #124 