### PR TITLE
Fix Montrose::Options#fetch

### DIFF
--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -152,7 +152,7 @@ module Montrose
       found = send(key)
       return found if found
       return args.first if args.length == 1
-      raise "Key #{key.inspect} not found" unless block
+      raise "Key #{key.inspect} not found" unless block_given?
 
       yield
     end


### PR DESCRIPTION
```console
NameError: undefined local variable or method `block' for #<Montrose::Options {:interval=>1}>
from /gems/ruby/2.7.0/gems/montrose-0.12.0/lib/montrose/options.rb:152:in `fetch'
```
or the block check should be removed