### PR TITLE
Add support for Rails 7 alpha/beta versions

### DIFF
--- a/montrose.gemspec
+++ b/montrose.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency "activesupport", ">= 5.2", "<= 7.0"
+  spec.add_dependency "activesupport", ">= 5.2", "< 7.0"
 
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "m"


### PR DESCRIPTION
Some people (like me) need to use alpha version of Ruby to run it using Ruby 3.1. Please, check official thread: https://github.com/rails/rails/issues/43998

