### PR TITLE
Change how clock ticks to O(n)

### DIFF
--- a/lib/montrose/clock.rb
+++ b/lib/montrose/clock.rb
@@ -58,9 +58,9 @@ module Montrose
     #
     # Returns next time using :at option. Tries to calculate
     # a time for the current date by incrementing the index
-    # to use of the :at option. Once all items have been
-    # exhausted the minimum time is generated for the current
-    # date and we advance to the next date
+    # of the :at option. Once all items have been exhausted
+    # the minimum time is generated for the current date and
+    # we advance to the next date based on interval
     #
     def next_time_at(time, tick)
       if current_at_index && (next_time = time_at(time, current_at_index + 1))

--- a/lib/montrose/clock.rb
+++ b/lib/montrose/clock.rb
@@ -10,31 +10,31 @@ module Montrose
       @every = @options.fetch(:every) { fail ConfigurationError, "Required option :every not provided" }
       @interval = @options.fetch(:interval)
       @start_time = @options.fetch(:start_time)
-      @at = @options.fetch(:at, nil)
+      @at = @options.fetch(:at, []).sort
     end
 
     # Advances time to new unit by increment and sets
     # new time as "current" time for next tick
     #
     def tick
-      @time = peek
+      @time = next_time(true)
     end
 
     def peek
+      next_time(false)
+    end
+
+    private
+
+    def next_time(tick)
       return @start_time if @time.nil?
 
-      if @at
-        times = @at.map { |hour, min, sec = 0| @time.change(hour: hour, min: min, sec: sec) }
-
-        (min_next = times.select { |t| t > @time }.min) && (return min_next)
-
-        advance_step(times.min || @time)
+      if @at.present?
+        next_time_at(@time, tick)
       else
         advance_step(@time)
       end
     end
-
-    private
 
     def advance_step(time)
       time.advance(step)
@@ -52,6 +52,51 @@ module Montrose
         unit_step(:week) ||
         unit_step(:month) ||
         unit_step(:year)
+    end
+
+    # @private
+    #
+    # Returns next time using :at option. Tries to calculate
+    # a time for the current date by incrementing the index
+    # to use of the :at option. Once all items have been
+    # exhausted the minimum time is generated for the current
+    # date and we advance to the next date
+    #
+    def next_time_at(time, tick)
+      if current_at_index && (next_time = time_at(time, current_at_index + 1))
+        @current_at_index += 1 if tick
+
+        next_time
+      else
+        min_time = time_at(time, 0)
+        @current_at_index = 0 if tick
+
+        advance_step(min_time)
+      end
+    end
+
+    # @private
+    #
+    # Returns time with hour, minute and second from :at option
+    # at specified index
+    #
+    def time_at(time, index)
+      parts = @at[index]
+
+      return unless parts
+
+      hour, min, sec = parts
+      time.change(hour: hour, min: min, sec: sec || 0)
+    end
+
+    # @private
+    #
+    # Keep track of which index we are currently at for :at option.
+    #
+    def current_at_index
+      @current_at_index ||= @at.index do |hour, min, sec = 0|
+        @start_time.hour == hour && @start_time.min == min && @start_time.sec == sec
+      end
     end
 
     # @private

--- a/spec/montrose/clock_spec.rb
+++ b/spec/montrose/clock_spec.rb
@@ -115,4 +115,26 @@ describe Montrose::Clock do
       _(clock).must_have_tick 1.day
     end
   end
+
+  describe "#peek" do
+    it "does not cause clock to tick" do
+      Timecop.freeze(Time.local(2018, 5, 31, 11)) do
+        clock = new_clock(every: :day, at: [[10, 0, 59], [15, 30, 34]])
+
+        _(clock.peek).must_equal Time.local(2018, 5, 31, 15, 30, 34)
+        _(clock.peek).must_equal Time.local(2018, 5, 31, 15, 30, 34)
+        _(clock.tick).must_equal Time.local(2018, 5, 31, 15, 30, 34)
+        _(clock.peek).must_equal Time.local(2018, 6, 1, 10, 0, 59)
+        _(clock.peek).must_equal Time.local(2018, 6, 1, 10, 0, 59)
+        _(clock.tick).must_equal Time.local(2018, 6, 1, 10, 0, 59)
+        _(clock.peek).must_equal Time.local(2018, 6, 1, 15, 30, 34)
+        _(clock.peek).must_equal Time.local(2018, 6, 1, 15, 30, 34)
+        _(clock.tick).must_equal Time.local(2018, 6, 1, 15, 30, 34)
+        _(clock.peek).must_equal Time.local(2018, 6, 2, 10, 0, 59)
+        _(clock.tick).must_equal Time.local(2018, 6, 2, 10, 0, 59)
+        _(clock.peek).must_equal Time.local(2018, 6, 2, 15, 30, 34)
+        _(clock.tick).must_equal Time.local(2018, 6, 2, 15, 30, 34)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The current implementation of `tick` and `peek` method in `Clock` class is slow for large number of `:at` values for a modestly large date range. For example:

```
# 50 times a day for next 30 days.
recurrence = Montrose.r({:every=>"day", :at=>["9:00", "9:30", "9:45", "10:00", "10:15", "10:30", "10:45", "11:00", "11:15", "11:45", "12:00", "12:15", "12:30", "12:45", "13:00", "13:15", "13:30", "14:00", "14:15", "14:30", "14:45", "15:00", "15:15", "15:30", "15:45", "16:00", "16:30", "16:45", "17:00", "17:15", "17:30", "17:45", "18:00", "18:15", "18:45", "19:00", "19:15", "19:30", "19:45", "20:00", "20:15", "20:30", "21:00", "21:15", "21:30", "21:45", "22:00", "22:15", "22:30", "22:45"], :starts=>Time.current, :until=>30.days.from_now, :interval=>1})

recurrence.events
```
Current implementation takes an average of 500-550ms. This change generates times in O(n) and the same operation takes around 30-35ms. 

The other option I considered was to simply cache the `times` for each unique date. I believe this resulted in operation taking around 50-70ms. That change would involve adding a Hash to cache the times for a date and only generate them once instead of every time the clock ticks. I opted for the current solution since it was about 2x faster and didn't require additional memory.

There are a couple of oddities I noticed that are assumed in the `Clock` class based on `Options`. `Options` will attempt to set `start_time` to a value matching one of the `:at` options if possible. This means that the `Options` were able to find a time using `:at` option that is the earliest time which occurs after `:starts` option. I believe the only case it won't is when the `:starts` option time is after any of the :at times (e.g. `:at => ['9:00AM', '11:00AM'], starts: Time.current.change(hour: 12))`. In this case it will simply return the `:starts` options. The `current_index_at` takes these assumptions into consideration:

* If `Options` class is able to pick a time with an `:at` from options we need to move index pointer to the index of that `:at` option.
* If `Options` class returned a start time that does not match any of the `:at` options because they would all result in times before the `:starts` option current_index_at is nil. In this case we assume, based on `Options` class logic that we need to move on to the minimum time on the next date based on interval.

