### PR TITLE
Add exclude_end for rule During

### DIFF
--- a/lib/montrose/rule/during.rb
+++ b/lib/montrose/rule/during.rb
@@ -6,15 +6,22 @@ module Montrose
       include Montrose::Rule
 
       def self.apply_options(opts)
-        opts[:during]
+        return false unless opts[:during]
+
+        {during: opts[:during], exclude_end: opts.fetch(:exclude_end, false)}
       end
 
-      # Initializes rule
-      #
-      # @param during [Array<Array<Fixnum>>] array of time parts arrays, e.g. [[9, 0, 0], [17, 0, 0]], i.e., "9 to 5"
-      #
-      def initialize(during)
-        @during = during.map { |first, last| TimeOfDayRange.new(first, last) }
+      def initialize(opts)
+        case opts
+        when Hash
+          during = opts.fetch(:during)
+          @exclude_end = opts.fetch(:exclude_end, false)
+        else
+          during = opts
+          @exclude_end = false
+        end
+
+        @during = during.map { |first, last| TimeOfDayRange.new(first, last, exclude_end: @exclude_end) }
       end
 
       def include?(time)

--- a/lib/montrose/rule/until.rb
+++ b/lib/montrose/rule/until.rb
@@ -8,7 +8,7 @@ module Montrose
       def self.apply_options(opts)
         return false unless opts[:until]
 
-        {until: opts[:until], exclude_end: opts.fetch(:exclude_end, false)}
+        { until: opts[:until], exclude_end: opts.fetch(:exclude_end, false) }
       end
 
       def initialize(opts)

--- a/spec/montrose/rule/during_spec.rb
+++ b/spec/montrose/rule/during_spec.rb
@@ -44,4 +44,18 @@ describe Montrose::Rule::During do
       it { refute rule.include?(time_of_day(23, 59, 0)) }
     end
   end
+
+  describe "exclude end" do
+    let(:rule) { Montrose::Rule::During.new(during: [[[9, 0, 0], [17, 0, 0]]], exclude_end: true) }
+
+    describe "#include?" do
+      it { refute rule.include?(time_of_day(0, 0, 0)) }
+      it { refute rule.include?(time_of_day(8, 59, 0)) }
+      it { assert rule.include?(time_of_day(9, 0, 0)) }
+      it { assert rule.include?(time_of_day(12, 0, 0)) }
+      it { refute rule.include?(time_of_day(17, 0, 0)) }
+      it { refute rule.include?(time_of_day(17, 1, 0)) }
+      it { refute rule.include?(time_of_day(23, 59, 0)) }
+    end
+  end
 end


### PR DESCRIPTION
Added support for supporting `exclude_end` for the During-Rule.

Example:

``` ruby
Montrose
.every(15.minutes, until: Date.today.end_of_day, exclude_end: true)
.starting(Date.today)
.during(
  "14:00-15:00",
)
```

Generated events in the current version:

``` ruby
[
  2023-07-21 14:00:00 +0200,
  2023-07-21 14:15:00 +0200,
  2023-07-21 14:30:00 +0200,
  2023-07-21 14:45:00 +0200,
  2023-07-21 15:00:00 +0200
]
```

Generated events in the new version:

``` ruby
[
  2023-07-21 14:00:00 +0200,
  2023-07-21 14:15:00 +0200,
  2023-07-21 14:30:00 +0200,
  2023-07-21 14:45:00 +0200
]
```

