### PR TITLE
chore: support rails 7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,7 @@ workflows:
                 - 'gemfiles/activesupport_6.0.gemfile'
                 - 'gemfiles/activesupport_6.1.gemfile'
                 - 'gemfiles/activesupport_7.0.gemfile'
+                - 'gemfiles/activesupport_7.1.gemfile'
       - publish-docs:
           requires:
             - lint

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     montrose (0.15.0)
-      activesupport (>= 5.2, < 7.1)
+      activesupport (>= 5.2, <= 7.1)
 
 GEM
   remote: https://rubygems.org/
@@ -145,4 +145,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.4.10
+   2.4.20

--- a/gemfiles/activesupport_7.1.gemfile
+++ b/gemfiles/activesupport_7.1.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 7.1"
+
+gemspec path: "../"

--- a/montrose.gemspec
+++ b/montrose.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7.0"
 
-  spec.add_dependency "activesupport", ">= 5.2", "< 7.1"
+  spec.add_dependency "activesupport", ">= 5.2", "<= 7.1"
 
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "m"


### PR DESCRIPTION
It would be great to use rails 7.1 with this gem, so I have attempted to add support base of the [7.0 update](https://github.com/rossta/montrose/commit/2656999643b3f7791c9b72a4c6f9ddee2a55c9b7)
