### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ schedule = Montrose::Schedule.build do |s|
 end
 
 # add after building
-s << Montrose.yearly
+schedule << Montrose.yearly
 ```
 
 The `Schedule#<<` method also accepts valid recurrence options as hashes:


### PR DESCRIPTION
Example code references `s` as variable instead of `schedule`. `s` is scoped to block in call to `Montrose::Schedule.build`.